### PR TITLE
fix: apply enum for ruling source

### DIFF
--- a/src/objects/Ruling/Ruling.ts
+++ b/src/objects/Ruling/Ruling.ts
@@ -9,7 +9,7 @@ export type ScryfallRuling = ScryfallObject.Object<ScryfallObject.ObjectType.Rul
   /**
    * A computer-readable string indicating which company produced this ruling, either `wotc` or `scryfall`
    */
-  source: string;
+  source: "wotc" | "scryfall";
   /**
    * The date when the ruling or note was published
    */


### PR DESCRIPTION
Updates ruling definition to only allow `"wotc"` or `"scryfall"` as values for `source` (as per the documentation)