### PR TITLE
fix: correct path to internal types

### DIFF
--- a/src/objects/Card/values/ImageUris.ts
+++ b/src/objects/Card/values/ImageUris.ts
@@ -1,4 +1,5 @@
-import { Uri } from "../../../../src/internal";
+import { Uri } from "../../../internal";
+
 import { ScryfallImageSize } from "./ImageSize";
 
 /**

--- a/src/objects/Card/values/ImageUris.ts
+++ b/src/objects/Card/values/ImageUris.ts
@@ -1,4 +1,4 @@
-import { Uri } from "src/internal";
+import { Uri } from "../../../../src/internal";
 import { ScryfallImageSize } from "./ImageSize";
 
 /**

--- a/src/objects/Card/values/PurchaseUris.ts
+++ b/src/objects/Card/values/PurchaseUris.ts
@@ -1,4 +1,5 @@
-import { Uri } from "../../../../src/internal";
+import { Uri } from "../../../internal";
+
 
 /**
  * Possible purchase URIs for a card.

--- a/src/objects/Card/values/PurchaseUris.ts
+++ b/src/objects/Card/values/PurchaseUris.ts
@@ -1,4 +1,4 @@
-import { Uri } from "src/internal";
+import { Uri } from "../../../../src/internal";
 
 /**
  * Possible purchase URIs for a card.

--- a/src/objects/Card/values/RelatedUris.ts
+++ b/src/objects/Card/values/RelatedUris.ts
@@ -1,4 +1,5 @@
-import { Uri } from "../../../../src/internal";
+import { Uri } from "../../../internal";
+
 
 /**
  * Related URIs for a card.

--- a/src/objects/Card/values/RelatedUris.ts
+++ b/src/objects/Card/values/RelatedUris.ts
@@ -1,4 +1,4 @@
-import { Uri } from "src/internal";
+import { Uri } from "../../../../src/internal";
 
 /**
  * Related URIs for a card.


### PR DESCRIPTION
Was getting typescript compilation errors when using the module:

```
npm run typescript

> scryfall-client@0.23.1 typescript
> tsc --declaration

node_modules/@scryfall/api-types/src/objects/Card/values/ImageUris.ts:1:21 - error TS2307: Cannot find module 'src/internal' or its corresponding type declarations.

1 import { Uri } from "src/internal";
                      ~~~~~~~~~~~~~~

node_modules/@scryfall/api-types/src/objects/Card/values/PurchaseUris.ts:1:21 - error TS2307: Cannot find module 'src/internal' or its corresponding type declarations.

1 import { Uri } from "src/internal";
                      ~~~~~~~~~~~~~~

node_modules/@scryfall/api-types/src/objects/Card/values/RelatedUris.ts:1:21 - error TS2307: Cannot find module 'src/internal' or its corresponding type declarations.

1 import { Uri } from "src/internal";
                      ~~~~~~~~~~~~~~


Found 3 errors in 3 files.

Errors  Files
     1  node_modules/@scryfall/api-types/src/objects/Card/values/ImageUris.ts:1
     1  node_modules/@scryfall/api-types/src/objects/Card/values/PurchaseUris.ts:1
     1  node_modules/@scryfall/api-types/src/objects/Card/values/RelatedUris.ts:1
```

Correcting these paths to point to the correct relative path fixed the issue for me.