### PR TITLE
Add ScryfallCard.Unknown type via Overlap utility type

### DIFF
--- a/__test__/global.d.ts
+++ b/__test__/global.d.ts
@@ -2,5 +2,7 @@ import { ScryfallCard } from "../src";
 import { ScryfallObject } from "../src/objects/Object";
 
 declare global {
-  type TestCard<T extends ScryfallObject.Object<ScryfallObject.ObjectType.Card>> = T & ScryfallCard.Any;
+  type TestCard<T extends ScryfallObject.Object<ScryfallObject.ObjectType.Card>> = T &
+    ScryfallCard.Any &
+    ScryfallCard.Unknown;
 }

--- a/src/internal/UtilityTypes.ts
+++ b/src/internal/UtilityTypes.ts
@@ -1,0 +1,2 @@
+export type Overlap<A, B> = Partial<Omit<A, keyof B>> | Partial<Omit<B, keyof A>> | (A | B);
+export type Overlap3<A, B, C> = Overlap<Overlap<A, B>, C>;

--- a/src/internal/UtilityTypes.ts
+++ b/src/internal/UtilityTypes.ts
@@ -1,2 +1,3 @@
-export type Overlap<A, B> = Partial<Omit<A, keyof B>> | Partial<Omit<B, keyof A>> | (A | B);
+export type Overlap<A, B> = Partial<Omit<A, keyof B>> & Partial<Omit<B, keyof A>> & (A | B);
 export type Overlap3<A, B, C> = Overlap<Overlap<A, B>, C>;
+export type Overlap4<A, B, C, D> = Overlap<Overlap<A, B>, Overlap<C, D>>;

--- a/src/internal/index.ts
+++ b/src/internal/index.ts
@@ -1,1 +1,2 @@
 export * from "./Primitives";
+export * from "./UtilityTypes";

--- a/src/objects/Card/Card.ts
+++ b/src/objects/Card/Card.ts
@@ -2,6 +2,7 @@ import { ScryfallObject } from "../Object";
 import { ScryfallLayout, ScryfallLayoutGroup } from "./values";
 import { ScryfallCardFace } from "./CardFace";
 import { ScryfallCardFields } from "./CardFields";
+import { Overlap3 } from "../../internal";
 
 type Layout<T extends ScryfallLayout> = Pick<ScryfallCardFields.Core.All, "layout"> & {
   layout: T | `${T}`;
@@ -187,6 +188,16 @@ export namespace ScryfallCard {
     | DoubleFacedToken
     | ArtSeries
     | ReversibleCard;
+
+  /**
+   * A card with a completely unknown data format.
+   *
+   * Any possible field allowed in any possible layout may be present here.
+   *
+   * No type narrowing is available on this card.
+   */
+  export type Unknown = Overlap3<SingleFace, SingleSidedSplit, DoubleSidedSplit> &
+    ScryfallCardFields.Gameplay.CombatStats;
 
   /**
    * Any card with a single-faced layout. These all have a .

--- a/src/objects/Card/Card.ts
+++ b/src/objects/Card/Card.ts
@@ -2,7 +2,7 @@ import { ScryfallObject } from "../Object";
 import { ScryfallLayout, ScryfallLayoutGroup } from "./values";
 import { ScryfallCardFace } from "./CardFace";
 import { ScryfallCardFields } from "./CardFields";
-import { Overlap3 } from "../../internal";
+import { Overlap4 } from "../../internal";
 
 type Layout<T extends ScryfallLayout> = Pick<ScryfallCardFields.Core.All, "layout"> & {
   layout: T | `${T}`;
@@ -193,11 +193,10 @@ export namespace ScryfallCard {
    * A card with a completely unknown data format.
    *
    * Any possible field allowed in any possible layout may be present here.
-   *
-   * No type narrowing is available on this card.
    */
-  export type Unknown = Overlap3<SingleFace, SingleSidedSplit, DoubleSidedSplit> &
-    ScryfallCardFields.Gameplay.CombatStats;
+  export type Unknown = Overlap4<SingleFace, SingleSidedSplit, DoubleSidedSplit, ReversibleCard> &
+    Partial<ScryfallCardFields.Gameplay.CombatStats> &
+    Partial<ScryfallCardFields.Gameplay.VanguardStats>;
 
   /**
    * Any card with a single-faced layout. These all have a .


### PR DESCRIPTION
This adds a new card object type, `ScryfallCard.Unknown`. It has the following behaviour:

- All fields that exist on literally every layout will be required.
- All fields that MIGHT exist on SOME type will be partially present.

This operates via overlap4, which seems like it might not grow very performantly as more variations appear.