### PR TITLE
Add ScryfallCard.Unknown via range of partials

### DIFF
--- a/__test__/Card/layouts/Adventure/AltarOfBhaal.ts
+++ b/__test__/Card/layouts/Adventure/AltarOfBhaal.ts
@@ -159,3 +159,5 @@ const AltarOfBhaal: TestCard<ScryfallCard.Adventure> = {
       "https://www.cardhoarder.com/cards?affiliate_id=scryfall&data%5Bsearch%5D=Altar+of+Bhaal&ref=card-profile&utm_campaign=affiliate&utm_medium=card&utm_source=scryfall",
   },
 };
+
+const AltarOfBhaal_Unknown: ScryfallCard.Unknown = AltarOfBhaal;

--- a/__test__/Card/layouts/Adventure/AltarOfBhaal.ts
+++ b/__test__/Card/layouts/Adventure/AltarOfBhaal.ts
@@ -160,4 +160,4 @@ const AltarOfBhaal: TestCard<ScryfallCard.Adventure> = {
   },
 };
 
-const AltarOfBhaal_Unknown: ScryfallCard.Unknown = AltarOfBhaal;
+const AltarOfBhaal_Unknown: ScryfallCard.Blob = AltarOfBhaal;

--- a/__test__/Card/layouts/DoubleFacedToken/AngelDfc.ts
+++ b/__test__/Card/layouts/DoubleFacedToken/AngelDfc.ts
@@ -140,3 +140,5 @@ const Angel: TestCard<ScryfallCard.DoubleFacedToken> = {
       "https://www.cardhoarder.com/cards?affiliate_id=scryfall&data%5Bsearch%5D=Angel+%2F%2F+Angel&ref=card-profile&utm_campaign=affiliate&utm_medium=card&utm_source=scryfall",
   },
 };
+
+const Angel_Unknown: ScryfallCard.Unknown = Angel;

--- a/__test__/Card/layouts/DoubleFacedToken/AngelDfc.ts
+++ b/__test__/Card/layouts/DoubleFacedToken/AngelDfc.ts
@@ -141,4 +141,4 @@ const Angel: TestCard<ScryfallCard.DoubleFacedToken> = {
   },
 };
 
-const Angel_Unknown: ScryfallCard.Unknown = Angel;
+const Angel_Unknown: ScryfallCard.Blob = Angel;

--- a/__test__/Card/layouts/Flip/AkkiLavarunner.ts
+++ b/__test__/Card/layouts/Flip/AkkiLavarunner.ts
@@ -143,3 +143,5 @@ const AkkiLavarunner: TestCard<ScryfallCard.Flip> = {
       "https://www.cardhoarder.com/cards/21237?affiliate_id=scryfall&ref=card-profile&utm_campaign=affiliate&utm_medium=card&utm_source=scryfall",
   },
 };
+
+const AkkiLavarunner_Unknown: ScryfallCard.Unknown = AkkiLavarunner;

--- a/__test__/Card/layouts/Flip/AkkiLavarunner.ts
+++ b/__test__/Card/layouts/Flip/AkkiLavarunner.ts
@@ -144,4 +144,4 @@ const AkkiLavarunner: TestCard<ScryfallCard.Flip> = {
   },
 };
 
-const AkkiLavarunner_Unknown: ScryfallCard.Unknown = AkkiLavarunner;
+const AkkiLavarunner_Unknown: ScryfallCard.Blob = AkkiLavarunner;

--- a/__test__/Card/layouts/ModalDfc/Esika.ts
+++ b/__test__/Card/layouts/ModalDfc/Esika.ts
@@ -158,3 +158,5 @@ const Esika: TestCard<ScryfallCard.ModalDfc> = {
       "https://www.cardhoarder.com/cards/87673?affiliate_id=scryfall&ref=card-profile&utm_campaign=affiliate&utm_medium=card&utm_source=scryfall",
   },
 };
+
+const Esika_Unknown: ScryfallCard.Unknown = Esika;

--- a/__test__/Card/layouts/ModalDfc/Esika.ts
+++ b/__test__/Card/layouts/ModalDfc/Esika.ts
@@ -159,4 +159,4 @@ const Esika: TestCard<ScryfallCard.ModalDfc> = {
   },
 };
 
-const Esika_Unknown: ScryfallCard.Unknown = Esika;
+const Esika_Unknown: ScryfallCard.Blob = Esika;

--- a/__test__/Card/layouts/Normal/Creature/DryadArbor.ts
+++ b/__test__/Card/layouts/Normal/Creature/DryadArbor.ts
@@ -125,3 +125,4 @@ const DryadArbor: TestCard<ScryfallCard.Normal> = {
       "https://www.cardhoarder.com/cards/86929?affiliate_id=scryfall&ref=card-profile&utm_campaign=affiliate&utm_medium=card&utm_source=scryfall",
   },
 };
+const DryadArbor_Unknown: ScryfallCard.Unknown = DryadArbor;

--- a/__test__/Card/layouts/Normal/Creature/DryadArbor.ts
+++ b/__test__/Card/layouts/Normal/Creature/DryadArbor.ts
@@ -125,4 +125,4 @@ const DryadArbor: TestCard<ScryfallCard.Normal> = {
       "https://www.cardhoarder.com/cards/86929?affiliate_id=scryfall&ref=card-profile&utm_campaign=affiliate&utm_medium=card&utm_source=scryfall",
   },
 };
-const DryadArbor_Unknown: ScryfallCard.Unknown = DryadArbor;
+const DryadArbor_Unknown: ScryfallCard.Blob = DryadArbor;

--- a/__test__/Card/layouts/ReversibleCard/Ajani.ts
+++ b/__test__/Card/layouts/ReversibleCard/Ajani.ts
@@ -169,4 +169,4 @@ const Ajani: TestCard<ScryfallCard.ReversibleCard> = {
   },
 };
 
-const Ajani_Unknown: ScryfallCard.Unknown = Ajani;
+const Ajani_Unknown: ScryfallCard.Blob = Ajani;

--- a/__test__/Card/layouts/ReversibleCard/Ajani.ts
+++ b/__test__/Card/layouts/ReversibleCard/Ajani.ts
@@ -168,3 +168,5 @@ const Ajani: TestCard<ScryfallCard.ReversibleCard> = {
       "https://www.cardhoarder.com/cards?affiliate_id=scryfall&data%5Bsearch%5D=Ajani+Goldmane+%2F%2F+Ajani+Goldmane&ref=card-profile&utm_campaign=affiliate&utm_medium=card&utm_source=scryfall",
   },
 };
+
+const Ajani_Unknown: ScryfallCard.Unknown = Ajani;

--- a/__test__/Card/layouts/Vanguard/Akroma.ts
+++ b/__test__/Card/layouts/Vanguard/Akroma.ts
@@ -112,3 +112,5 @@ const Akroma: TestCard<ScryfallCard.Vanguard> = {
       "https://www.cardhoarder.com/cards/19?affiliate_id=scryfall&ref=card-profile&utm_campaign=affiliate&utm_medium=card&utm_source=scryfall",
   },
 };
+
+const Akroma_Unknown: ScryfallCard.Unknown = Akroma;

--- a/__test__/Card/layouts/Vanguard/Akroma.ts
+++ b/__test__/Card/layouts/Vanguard/Akroma.ts
@@ -113,4 +113,4 @@ const Akroma: TestCard<ScryfallCard.Vanguard> = {
   },
 };
 
-const Akroma_Unknown: ScryfallCard.Unknown = Akroma;
+const Akroma_Unknown: ScryfallCard.Blob = Akroma;

--- a/__test__/Card/localized/Phyrexian.ts
+++ b/__test__/Card/localized/Phyrexian.ts
@@ -123,3 +123,5 @@ const PhyrexianArena: TestCard<ScryfallCard.Any> = {
       "https://www.cardhoarder.com/cards?affiliate_id=scryfall&data%5Bsearch%5D=Phyrexian+Arena&ref=card-profile&utm_campaign=affiliate&utm_medium=card&utm_source=scryfall",
   },
 };
+
+const PhyrexianArena_Unknown: ScryfallCard.Unknown = PhyrexianArena;

--- a/__test__/Card/localized/Phyrexian.ts
+++ b/__test__/Card/localized/Phyrexian.ts
@@ -124,4 +124,4 @@ const PhyrexianArena: TestCard<ScryfallCard.Any> = {
   },
 };
 
-const PhyrexianArena_Unknown: ScryfallCard.Unknown = PhyrexianArena;
+const PhyrexianArena_Unknown: ScryfallCard.Blob = PhyrexianArena;

--- a/__test__/global.d.ts
+++ b/__test__/global.d.ts
@@ -2,5 +2,7 @@ import { ScryfallCard } from "../src";
 import { ScryfallObject } from "../src/objects/Object";
 
 declare global {
-  type TestCard<T extends ScryfallObject.Object<ScryfallObject.ObjectType.Card>> = T & ScryfallCard.Any;
+  type TestCard<T extends ScryfallObject.Object<ScryfallObject.ObjectType.Card>> = T &
+    ScryfallCard.Any &
+    ScryfallCard.Unknown;
 }

--- a/__test__/global.d.ts
+++ b/__test__/global.d.ts
@@ -2,7 +2,5 @@ import { ScryfallCard } from "../src";
 import { ScryfallObject } from "../src/objects/Object";
 
 declare global {
-  type TestCard<T extends ScryfallObject.Object<ScryfallObject.ObjectType.Card>> = T &
-    ScryfallCard.Any &
-    ScryfallCard.Unknown;
+  type TestCard<T extends ScryfallObject.Object<ScryfallObject.ObjectType.Card>> = T & ScryfallCard.Any;
 }

--- a/src/internal/UtilityTypes.ts
+++ b/src/internal/UtilityTypes.ts
@@ -1,0 +1,1 @@
+export type SomePartial<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, K>>;

--- a/src/internal/index.ts
+++ b/src/internal/index.ts
@@ -1,1 +1,2 @@
 export * from "./Primitives";
+export * from "./UtilityTypes";

--- a/src/objects/Card/Card.ts
+++ b/src/objects/Card/Card.ts
@@ -2,6 +2,7 @@ import { ScryfallObject } from "../Object";
 import { ScryfallLayout, ScryfallLayoutGroup } from "./values";
 import { ScryfallCardFace } from "./CardFace";
 import { ScryfallCardFields } from "./CardFields";
+import { SomePartial } from "src/internal";
 
 type Layout<T extends ScryfallLayout> = Pick<ScryfallCardFields.Core.All, "layout"> & {
   layout: T | `${T}`;
@@ -150,8 +151,8 @@ export namespace ScryfallCard {
   /** A card with the ReversibleCard layout. */
   export type ReversibleCard = Layout<ScryfallLayout.ReversibleCard> &
     Omit<AbstractCard, "oracle_id"> &
-    ScryfallCardFields.Gameplay.RootProperties &
     Omit<ScryfallCardFields.Gameplay.CardSpecific, "type_line" | "cmc"> &
+    ScryfallCardFields.Gameplay.RootProperties &
     ScryfallCardFields.Gameplay.CardFaces<ScryfallCardFace.Reversible> &
     ScryfallCardFields.Print.RootProperties &
     ScryfallCardFields.Print.CardSpecific;
@@ -188,15 +189,24 @@ export namespace ScryfallCard {
     | ArtSeries
     | ReversibleCard;
 
-  export type Unknown = Omit<AbstractCard, "oracle_id"> &
-    Partial<Pick<AbstractCard, "oracle_id">> &
-    (
-      | Partial<SingleFace>
-      | Partial<SingleSidedSplit>
-      | Partial<DoubleSidedSplit>
-      | Partial<ReversibleCard>
-      | Partial<Vanguard>
-    );
+  type ReversibleCardBlob = SomePartial<AbstractCard, "oracle_id"> &
+    SomePartial<ScryfallCardFields.Gameplay.CardSpecific, "type_line" | "cmc"> &
+    ScryfallCardFields.Gameplay.RootProperties &
+    ScryfallCardFields.Gameplay.CardFaces<ScryfallCardFace.Reversible> &
+    ScryfallCardFields.Print.RootProperties &
+    ScryfallCardFields.Print.CardSpecific;
+    type AllFightingStats = (Partial<ScryfallCardFields.Gameplay.CombatStats> & Partial<ScryfallCardFields.Gameplay.VanguardStats>)
+  export type Blob = AbstractCard &
+    (Partial<SingleFace> &
+      Partial<SingleSidedSplit> &
+      Partial<DoubleSidedSplit> &
+      Partial<Vanguard> &
+      Partial<ReversibleCardBlob>) &
+     &AllFightingStats
+    ScryfallCardFields.Gameplay.CardFaces<
+      ScryfallCardFace.AbstractCardFace &
+      AllFightingStats
+    >;
 
   /**
    * Any card with a single-faced layout. These all have a .

--- a/src/objects/Card/Card.ts
+++ b/src/objects/Card/Card.ts
@@ -188,6 +188,16 @@ export namespace ScryfallCard {
     | ArtSeries
     | ReversibleCard;
 
+  export type Unknown = Omit<AbstractCard, "oracle_id"> &
+    Partial<Pick<AbstractCard, "oracle_id">> &
+    (
+      | Partial<SingleFace>
+      | Partial<SingleSidedSplit>
+      | Partial<DoubleSidedSplit>
+      | Partial<ReversibleCard>
+      | Partial<Vanguard>
+    );
+
   /**
    * Any card with a single-faced layout. These all have a .
    *


### PR DESCRIPTION
Like #4, this adds a ScryfallCard.Unknown field.

It does so by guaranteeing some specific gameplay fields, and then having everything else be a possible partial in addition to that.

This will grow more effectively than the Overlap method used in #4.