### PR TITLE
add "timeless" to Card/values/Format.ts

### DIFF
--- a/src/objects/Card/values/Format.ts
+++ b/src/objects/Card/values/Format.ts
@@ -19,4 +19,5 @@ export type ScryfallFormat =
   | "duel"
   | "oldschool"
   | "premodern"
-  | "predh";
+  | "predh"
+  | "timeless";


### PR DESCRIPTION
I noticed looking at some API results that there is this format in the legalities dictionary that isn't present in the api-types list of formats.