### PR TITLE
add `poster` to PrintAttribute.ts

### DIFF
--- a/src/objects/Card/values/PrintAttribute.ts
+++ b/src/objects/Card/values/PrintAttribute.ts
@@ -33,6 +33,7 @@ type ScryfallPrintAttribute =
   | "plastic"
   | "playerrewards"
   | "playpromo"
+  | "poster"
   | "premiereshop"
   | "prerelease"
   | "promopack"


### PR DESCRIPTION
Encountered in https://api.scryfall.com/cards/01a4a36a-f10a-411b-9558-cbbb62e8b4ae

Sorry if this is the wrong spot. I tried to follow your lead from https://github.com/scryfall/api-types/pull/9 and ScryfallPrintAttribute feeds into ScryfallPromoType along with ScryfallExtendedFinish. I figured between ScryfallPrintAttribute and ScryfallExtendedFinish, this makes more sense in ScryfallPrintAttribute ¯\_(ツ)_/¯ 