### PR TITLE
Simpler card model

### DIFF
--- a/src/internal/Primitives.ts
+++ b/src/internal/Primitives.ts
@@ -1,5 +1,0 @@
-export type Integer = number;
-export type Decimal = number;
-export type Uuid = string;
-export type Uri = string;
-export type IsoDate = string;

--- a/src/internal/index.ts
+++ b/src/internal/index.ts
@@ -1,1 +1,0 @@
-export * from "./Primitives";

--- a/src/objects/Card/Card.ts
+++ b/src/objects/Card/Card.ts
@@ -3,8 +3,8 @@ import { ScryfallLayout, ScryfallLayoutGroup } from "./values";
 import { ScryfallCardFace } from "./CardFace";
 import { ScryfallCardFields } from "./CardFields";
 
-type Layout<T extends ScryfallLayout> = Pick<ScryfallCardFields.Core.All, "layout"> & {
-  layout: T | `${T}`;
+type Layout<T extends `${ScryfallLayout}`> = Pick<ScryfallCardFields.Core.All, "layout"> & {
+  layout: `${T}`;
 };
 
 /**

--- a/src/objects/Card/Card.ts
+++ b/src/objects/Card/Card.ts
@@ -16,9 +16,10 @@ type Layout<T extends ScryfallLayout> = Pick<ScryfallCardFields.Core.All, "layou
  * Then various groups exist to help describe cards of indeterminate layout:
  * - {@link ScryfallCard.Any} describes any card at all. Think of it as like `any` but for cards.
  * - {@link ScryfallCard.AnySingleFaced} describes any card with one face and no `card_faces` property, e.g. {@link ScryfallCard.Normal Normal} or {@link ScryfallCard.Saga Saga}.
- * - {@link ScryfallCard.AnySplit} describes any split card: either a single-sided split or a double-sided split.
  * - {@link ScryfallCard.AnySingleSidedSplit} describes any card with multiple faces where both faces are on the front, e.g. {@link ScryfallCard.Adventure Adventure}, {@link ScryfallCard.Flip Flip}, or {@link ScryfallCard.Split Split}.
  * - {@link ScryfallCard.AnyDoubleSidedSplit} describes any card with multiple faces where the faces are on the front and back of the card, e.g.  {@link ScryfallCard.Transform Transform},  {@link ScryfallCard.ModalDfc ModalDfc}, or  {@link ScryfallCard.ReversibleCard ReversibleCard}.
+ * - {@link ScryfallCard.AnySplit} is an alias for either of the above two split types.
+ *
  * - {@link ScryfallCard.ReversibleCard} describes solely reversible cards.
  *
  * We recommend starting from `ScryfallCard.Any` to describe generic API responses, and you will need to do type narrowing to access more specific fields.

--- a/src/objects/Card/Card.ts
+++ b/src/objects/Card/Card.ts
@@ -122,7 +122,7 @@ export namespace ScryfallCard {
     ScryfallCardFields.Print.CardSpecific;
 
   /**
-   * Any split card layout.
+   * Any split layout, either single sided or double sided. These will both have `card_faces`.
    */
   export type AnySplit = AnySingleSidedSplit | AnyDoubleSidedSplit;
 

--- a/src/objects/Card/Card.ts
+++ b/src/objects/Card/Card.ts
@@ -45,8 +45,15 @@ type Layout<T extends ScryfallLayout> = Pick<ScryfallCardFields.Core.All, "layou
 export namespace ScryfallCard {
   /** The abstract root implementation of cards. */
   export type AbstractCard = ScryfallObject.Object<ScryfallObject.ObjectType.Card> & ScryfallCardFields.Core.All;
+}
 
-  type SingleFace = AbstractCard &
+export namespace ScryfallCard {
+  /**
+   * Any card with a single-faced layout.
+   *
+   * Examples: {@link ScryfallLayout.Normal}, {@link ScryfallLayout.Mutate}, {@link ScryfallLayout.Token}.
+   */
+  export type AnySingleFaced = AbstractCard &
     Layout<ScryfallLayoutGroup.SingleFaceType> &
     ScryfallCardFields.Gameplay.RootProperties &
     ScryfallCardFields.Gameplay.CardSpecific &
@@ -58,11 +65,57 @@ export namespace ScryfallCard {
     ScryfallCardFields.Print.CardSideSpecific &
     ScryfallCardFields.Print.CardFaceSpecific;
 
-  type MultiFace<T extends ScryfallCardFace.AbstractCardFace> = AbstractCard &
-    Layout<ScryfallLayoutGroup.MultiFaceType> &
+  /** A card with the Normal layout. */
+  export type Normal = AnySingleFaced & Layout<ScryfallLayout.Normal>;
+
+  /** A card with the Meld layout. */
+  export type Meld = AnySingleFaced & Layout<ScryfallLayout.Meld>;
+
+  /** A card with the Leveler layout. */
+  export type Leveler = AnySingleFaced & Layout<ScryfallLayout.Leveler>;
+
+  /** A card with the Class layout. */
+  export type Class = AnySingleFaced & Layout<ScryfallLayout.Class>;
+
+  /** A card with the Saga layout. */
+  export type Saga = AnySingleFaced & Layout<ScryfallLayout.Saga>;
+
+  /** A card with the Mutate layout. */
+  export type Mutate = AnySingleFaced & Layout<ScryfallLayout.Mutate>;
+
+  /** A card with the Prototype layout. */
+  export type Prototype = AnySingleFaced & Layout<ScryfallLayout.Prototype>;
+
+  /** A card with the Battle layout. */
+  export type Battle = AnySingleFaced & Layout<ScryfallLayout.Battle>;
+
+  /** A card with the Planar layout. */
+  export type Planar = AnySingleFaced & Layout<ScryfallLayout.Planar>;
+
+  /** A card with the Scheme layout. */
+  export type Scheme = AnySingleFaced & Layout<ScryfallLayout.Scheme>;
+
+  /** A card with the Vanguard layout. */
+  export type Vanguard = AnySingleFaced & Layout<ScryfallLayout.Vanguard>;
+
+  /** A card with the Token layout. */
+  export type Token = AnySingleFaced & Layout<ScryfallLayout.Token>;
+
+  /** A card with the Emblem layout. */
+  export type Emblem = AnySingleFaced & Layout<ScryfallLayout.Emblem>;
+
+  /** A card with the Augment layout. */
+  export type Augment = AnySingleFaced & Layout<ScryfallLayout.Augment>;
+
+  /** A card with the Host layout. */
+  export type Host = AnySingleFaced & Layout<ScryfallLayout.Host>;
+}
+
+export namespace ScryfallCard {
+  type MultiFace<Face extends ScryfallCardFace.AbstractCardFace> = AbstractCard &
     ScryfallCardFields.Gameplay.RootProperties &
     ScryfallCardFields.Gameplay.CardSpecific &
-    ScryfallCardFields.Gameplay.CardFaces<T> &
+    ScryfallCardFields.Gameplay.CardFaces<Face> &
     ScryfallCardFields.Print.RootProperties &
     ScryfallCardFields.Print.CardSpecific;
 
@@ -74,72 +127,50 @@ export namespace ScryfallCard {
 
   type DoubleSidedSplit = MultiFace<ScryfallCardFace.DoubleSided> & Layout<ScryfallLayoutGroup.DoubleSidedSplitType>;
 
-  /** A card with the Normal layout. */
-  export type Normal = Layout<ScryfallLayout.Normal> & SingleFace;
+  /**
+   * Any split card layout.
+   */
+  export type AnySplit = SingleSidedSplit | DoubleSidedSplit;
 
-  /** A card with the Meld layout. */
-  export type Meld = Layout<ScryfallLayout.Meld> & SingleFace;
-
-  /** A card with the Leveler layout. */
-  export type Leveler = Layout<ScryfallLayout.Leveler> & SingleFace;
-
-  /** A card with the Class layout. */
-  export type Class = Layout<ScryfallLayout.Class> & SingleFace;
-
-  /** A card with the Saga layout. */
-  export type Saga = Layout<ScryfallLayout.Saga> & SingleFace;
-
-  /** A card with the Mutate layout. */
-  export type Mutate = Layout<ScryfallLayout.Mutate> & SingleFace;
-
-  /** A card with the Prototype layout. */
-  export type Prototype = Layout<ScryfallLayout.Prototype> & SingleFace;
-
-  /** A card with the Battle layout. */
-  export type Battle = Layout<ScryfallLayout.Battle> & SingleFace;
-
-  /** A card with the Planar layout. */
-  export type Planar = Layout<ScryfallLayout.Planar> & SingleFace;
-
-  /** A card with the Scheme layout. */
-  export type Scheme = Layout<ScryfallLayout.Scheme> & SingleFace;
-
-  /** A card with the Vanguard layout. */
-  export type Vanguard = Layout<ScryfallLayout.Vanguard> & SingleFace;
-
-  /** A card with the Token layout. */
-  export type Token = Layout<ScryfallLayout.Token> & SingleFace;
-
-  /** A card with the Emblem layout. */
-  export type Emblem = Layout<ScryfallLayout.Emblem> & SingleFace;
-
-  /** A card with the Augment layout. */
-  export type Augment = Layout<ScryfallLayout.Augment> & SingleFace;
-
-  /** A card with the Host layout. */
-  export type Host = Layout<ScryfallLayout.Host> & SingleFace;
+  /**
+   * Any single-sided split card. These all have `card_faces`, and the faces are both on the front.
+   *
+   * Examples: {@link ScryfallLayout.Split}, {@link ScryfallLayout.Flip}, {@link ScryfallLayout.Adventure}.
+   */
+  export type AnySingleSidedSplit = Layout<ScryfallLayoutGroup.SingleSidedSplitType> &
+    SingleSidedSplit &
+    ScryfallCardFields.Gameplay.CombatStats;
 
   /** A card with the Split layout. */
-  export type Split = Layout<ScryfallLayout.Split> & SingleSidedSplit;
+  export type Split = AnySingleSidedSplit & Layout<ScryfallLayout.Split>;
 
   /** A card with the Flip layout. */
-  export type Flip = Layout<ScryfallLayout.Flip> & SingleSidedSplit & ScryfallCardFields.Gameplay.CombatStats;
+  export type Flip = AnySingleSidedSplit & Layout<ScryfallLayout.Flip>;
 
   /** A card with the Adventure layout. */
-  export type Adventure = Layout<ScryfallLayout.Adventure> & SingleSidedSplit & ScryfallCardFields.Gameplay.CombatStats;
+  export type Adventure = AnySingleSidedSplit & Layout<ScryfallLayout.Adventure>;
+
+  /**
+   * Any double-sided split card. These all have `card_faces`, and the faces are on the obverse and reverse of the card.
+   *
+   * Examples: {@link ScryfallLayout.Transform}, {@link ScryfallLayout.ModalDfc}, {@link ScryfallLayout.DoubleFacedToken}.
+   */
+  export type AnyDoubleSidedSplit = Layout<ScryfallLayoutGroup.DoubleSidedSplitType> & DoubleSidedSplit;
 
   /** A card with the Transform layout. */
-  export type Transform = Layout<ScryfallLayout.Transform> & DoubleSidedSplit;
+  export type Transform = AnyDoubleSidedSplit & Layout<ScryfallLayout.Transform>;
 
   /** A card with the ModalDfc layout. */
-  export type ModalDfc = Layout<ScryfallLayout.ModalDfc> & DoubleSidedSplit;
+  export type ModalDfc = AnyDoubleSidedSplit & Layout<ScryfallLayout.ModalDfc>;
 
   /** A card with the DoubleFacedToken layout. */
-  export type DoubleFacedToken = Layout<ScryfallLayout.DoubleFacedToken> & DoubleSidedSplit;
+  export type DoubleFacedToken = AnyDoubleSidedSplit & Layout<ScryfallLayout.DoubleFacedToken>;
 
   /** A card with the ArtSeries layout. */
-  export type ArtSeries = Layout<ScryfallLayout.ArtSeries> & DoubleSidedSplit;
+  export type ArtSeries = AnyDoubleSidedSplit & Layout<ScryfallLayout.ArtSeries>;
+}
 
+export namespace ScryfallCard {
   /** A card with the ReversibleCard layout. */
   export type ReversibleCard = Layout<ScryfallLayout.ReversibleCard> &
     Omit<AbstractCard, "oracle_id"> &
@@ -148,7 +179,9 @@ export namespace ScryfallCard {
     ScryfallCardFields.Gameplay.CardFaces<ScryfallCardFace.Reversible> &
     ScryfallCardFields.Print.RootProperties &
     ScryfallCardFields.Print.CardSpecific;
+}
 
+export namespace ScryfallCard {
   /**
    * A card with an indeterminate layout.
    *
@@ -156,58 +189,5 @@ export namespace ScryfallCard {
    *
    * Since this may be of any layout, common fields are available, but layout-specific fields (e.g. card_faces) will be unavailable until you perform type narrowing on
    */
-  export type Any =
-    | Normal
-    | Meld
-    | Leveler
-    | Class
-    | Saga
-    | Mutate
-    | Prototype
-    | Battle
-    | Planar
-    | Scheme
-    | Vanguard
-    | Token
-    | Emblem
-    | Augment
-    | Host
-    | Split
-    | Flip
-    | Adventure
-    | Transform
-    | ModalDfc
-    | DoubleFacedToken
-    | ArtSeries
-    | ReversibleCard;
-
-  /**
-   * Any card with a single-faced layout. These all have a .
-   *
-   * Examples: {@link Normal}, {@link Mutate}, {@link Token}.
-   */
-  export type AnySingleFaced = Any & Layout<ScryfallLayoutGroup.SingleFaceType>;
-
-  /**
-   * Any multi-faced layout, which is any that would have a `card_faces` field.
-   *
-   * @see {@link AnySingleSidedSplit} is in this group.
-   * @see {@link AnyDoubleSidedSplit} is in this group.
-   * @see {@link ReversibleCard} is in this group.
-   */
-  export type AnyMultiFaced = Any & Layout<ScryfallLayoutGroup.MultiFaceType>;
-
-  /**
-   * Any single-sided split card. These all have `card_faces`, and the faces are both on the front.
-   *
-   * Examples: {@link Split}, {@link Flip}, {@link Adventure}.
-   */
-  export type AnySingleSidedSplit = Any & Layout<ScryfallLayoutGroup.SingleSidedSplitType>;
-
-  /**
-   * Any double-sided split card. These all have `card_faces`, and the faces are on the obverse and reverse of the card.
-   *
-   * Examples: {@link Transform}, {@link ModalDfc}, {@link DoubleFacedToken}.
-   */
-  export type AnyDoubleSidedSplit = Any & Layout<ScryfallLayoutGroup.DoubleSidedSplitType>;
+  export type Any = AnySingleFaced | AnySingleSidedSplit | AnyDoubleSidedSplit | ReversibleCard;
 }

--- a/src/objects/Card/Card.ts
+++ b/src/objects/Card/Card.ts
@@ -22,7 +22,7 @@ type Layout<T extends `${ScryfallLayout}`> = Pick<ScryfallCardFields.Core.All, "
  * - {@link ScryfallCard.AnySplit} is an alias for either AnySingleSidedSplit or AnyDoubleSidedSplit.
  * - {@link ScryfallCard.AnyMultiFaced} is an alias for AnySingleSidedSplit, AnyDoubleSidedSplit, or Reversible. This describes all layouts that can have a `card_faces` field.
  *
- * We recommend starting from `ScryfallCard.Any` to describe generic API responses, and you will need to do type narrowing to access more specific fields.
+ * We recommend starting from {@link ScryfallCard.Any} to describe generic API responses, and you will need to do type narrowing to access more specific fields.
  *
  * An individual type additionally exists for each possible layout: {@link ScryfallCard.Normal}, {@link ScryfallCard.Transform}, etc, which is like the variety they belong to but with the `layout` field guaranteed to be a specific value.
  *

--- a/src/objects/Card/Card.ts
+++ b/src/objects/Card/Card.ts
@@ -18,9 +18,9 @@ type Layout<T extends ScryfallLayout> = Pick<ScryfallCardFields.Core.All, "layou
  * - {@link ScryfallCard.AnySingleFaced} describes any card with one face and no `card_faces` property, e.g. {@link ScryfallCard.Normal Normal} or {@link ScryfallCard.Saga Saga}.
  * - {@link ScryfallCard.AnySingleSidedSplit} describes any card with multiple faces where both faces are on the front, e.g. {@link ScryfallCard.Adventure Adventure}, {@link ScryfallCard.Flip Flip}, or {@link ScryfallCard.Split Split}.
  * - {@link ScryfallCard.AnyDoubleSidedSplit} describes any card with multiple faces where the faces are on the front and back of the card, e.g.  {@link ScryfallCard.Transform Transform},  {@link ScryfallCard.ModalDfc ModalDfc}, or  {@link ScryfallCard.ReversibleCard ReversibleCard}.
- * - {@link ScryfallCard.AnySplit} is an alias for either of the above two split types.
- *
  * - {@link ScryfallCard.ReversibleCard} describes solely reversible cards.
+ * - {@link ScryfallCard.AnySplit} is an alias for either AnySingleSidedSplit or AnyDoubleSidedSplit.
+ * - {@link ScryfallCard.AnyMultiFaced} is an alias for AnySingleSidedSplit, AnyDoubleSidedSplit, or Reversible. This describes all layouts that can have a `card_faces` field.
  *
  * We recommend starting from `ScryfallCard.Any` to describe generic API responses, and you will need to do type narrowing to access more specific fields.
  *
@@ -35,7 +35,7 @@ type Layout<T extends ScryfallLayout> = Pick<ScryfallCardFields.Core.All, "layou
  * const mysteryCard: ScryfallCard.Any = getCard();
  *
  * if ("card_faces" in mysteryCard) {
- *   const mfc: ScryfallCard.AnySplit = mysteryCard;
+ *   const mfc: ScryfallCard.AnyMultiFaced = mysteryCard;
  * } else {
  *   const sfc: ScryfallCard.AnySingleFaced = mysteryCard;
  * }
@@ -188,4 +188,9 @@ export namespace ScryfallCard {
    * Since this may be of any layout, common fields are available, but layout-specific fields (e.g. card_faces) will be unavailable until you perform type narrowing on
    */
   export type Any = AnySingleFaced | AnySingleSidedSplit | AnyDoubleSidedSplit | ReversibleCard;
+
+  /**
+   * Any card that is multifaced: either a single or double sided split layout, or a reversible card.
+   */
+  export type AnyMultiFaced = AnySingleSidedSplit | AnyDoubleSidedSplit | ReversibleCard;
 }

--- a/src/objects/Card/Card.ts
+++ b/src/objects/Card/Card.ts
@@ -121,27 +121,22 @@ export namespace ScryfallCard {
     ScryfallCardFields.Print.RootProperties &
     ScryfallCardFields.Print.CardSpecific;
 
-  type SingleSidedSplit = MultiFace<ScryfallCardFace.Split> &
-    Layout<ScryfallLayoutGroup.SingleSidedSplitType> &
-    ScryfallCardFields.Gameplay.CardSideSpecific &
-    ScryfallCardFields.Print.CardSideSpecific &
-    ScryfallCardFields.Print.SingleSideOnly;
-
-  type DoubleSidedSplit = MultiFace<ScryfallCardFace.DoubleSided> & Layout<ScryfallLayoutGroup.DoubleSidedSplitType>;
-
   /**
    * Any split card layout.
    */
-  export type AnySplit = SingleSidedSplit | DoubleSidedSplit;
+  export type AnySplit = AnySingleSidedSplit | AnyDoubleSidedSplit;
 
   /**
    * Any single-sided split card. These all have `card_faces`, and the faces are both on the front.
    *
    * Examples: {@link ScryfallLayout.Split}, {@link ScryfallLayout.Flip}, {@link ScryfallLayout.Adventure}.
    */
-  export type AnySingleSidedSplit = Layout<ScryfallLayoutGroup.SingleSidedSplitType> &
-    SingleSidedSplit &
-    ScryfallCardFields.Gameplay.CombatStats;
+  export type AnySingleSidedSplit = MultiFace<ScryfallCardFace.Split> &
+    Layout<ScryfallLayoutGroup.SingleSidedSplitType> &
+    ScryfallCardFields.Gameplay.CardSideSpecific &
+    ScryfallCardFields.Gameplay.CombatStats &
+    ScryfallCardFields.Print.CardSideSpecific &
+    ScryfallCardFields.Print.SingleSideOnly;
 
   /** A card with the Split layout. */
   export type Split = AnySingleSidedSplit & Layout<ScryfallLayout.Split>;
@@ -157,7 +152,8 @@ export namespace ScryfallCard {
    *
    * Examples: {@link ScryfallLayout.Transform}, {@link ScryfallLayout.ModalDfc}, {@link ScryfallLayout.DoubleFacedToken}.
    */
-  export type AnyDoubleSidedSplit = Layout<ScryfallLayoutGroup.DoubleSidedSplitType> & DoubleSidedSplit;
+  export type AnyDoubleSidedSplit = MultiFace<ScryfallCardFace.DoubleSided> &
+    Layout<ScryfallLayoutGroup.DoubleSidedSplitType>;
 
   /** A card with the Transform layout. */
   export type Transform = AnyDoubleSidedSplit & Layout<ScryfallLayout.Transform>;

--- a/src/objects/Card/Card.ts
+++ b/src/objects/Card/Card.ts
@@ -10,7 +10,6 @@ type Layout<T extends `${ScryfallLayout}`> = Pick<ScryfallCardFields.Core.All, "
 /**
  * A collection of types representing Scryfall cards of each possible layout.
  *
- *
  * This collection is focused around four core varieties of cards:
  * - {@link ScryfallCard.AnySingleFaced} describes any card with one face and no `card_faces` property, e.g. {@link ScryfallCard.Normal Normal} or {@link ScryfallCard.Saga Saga}.
  * - {@link ScryfallCard.AnySingleSidedSplit} describes any card with multiple faces where both faces are on the front, e.g. {@link ScryfallCard.Adventure Adventure}, {@link ScryfallCard.Flip Flip}, or {@link ScryfallCard.Split Split}.
@@ -25,8 +24,6 @@ type Layout<T extends `${ScryfallLayout}`> = Pick<ScryfallCardFields.Core.All, "
  * There is also an alias for each possible layout: {@link ScryfallCard.Normal}, {@link ScryfallCard.Transform}, etc.
  *
  * We recommend starting from {@link ScryfallCard.Any} to describe generic API responses, and you will need to do type narrowing to access more specific fields.
- *
- * 
  *
  * @example // Type narrowing by layout
  * const mysteryCard: ScryfallCard.Any = getCard();

--- a/src/objects/Card/Card.ts
+++ b/src/objects/Card/Card.ts
@@ -16,9 +16,10 @@ type Layout<T extends ScryfallLayout> = Pick<ScryfallCardFields.Core.All, "layou
  * Then various groups exist to help describe cards of indeterminate layout:
  * - {@link ScryfallCard.Any} describes any card at all. Think of it as like `any` but for cards.
  * - {@link ScryfallCard.AnySingleFaced} describes any card with one face and no `card_faces` property, e.g. {@link ScryfallCard.Normal Normal} or {@link ScryfallCard.Saga Saga}.
- * - {@link ScryfallCard.AnyMultiFaced} describes any card with multiple faces. It may be a split card with both "faces" on the front, or a double-sided card with faces on the front and back of the card. It also collects the next two groups on this list.
+ * - {@link ScryfallCard.AnySplit} describes any split card: either a single-sided split or a double-sided split.
  * - {@link ScryfallCard.AnySingleSidedSplit} describes any card with multiple faces where both faces are on the front, e.g. {@link ScryfallCard.Adventure Adventure}, {@link ScryfallCard.Flip Flip}, or {@link ScryfallCard.Split Split}.
  * - {@link ScryfallCard.AnyDoubleSidedSplit} describes any card with multiple faces where the faces are on the front and back of the card, e.g.  {@link ScryfallCard.Transform Transform},  {@link ScryfallCard.ModalDfc ModalDfc}, or  {@link ScryfallCard.ReversibleCard ReversibleCard}.
+ * - {@link ScryfallCard.ReversibleCard} describes solely reversible cards.
  *
  * We recommend starting from `ScryfallCard.Any` to describe generic API responses, and you will need to do type narrowing to access more specific fields.
  *
@@ -33,7 +34,7 @@ type Layout<T extends ScryfallLayout> = Pick<ScryfallCardFields.Core.All, "layou
  * const mysteryCard: ScryfallCard.Any = getCard();
  *
  * if ("card_faces" in mysteryCard) {
- *   const mfc: ScryfallCard.AnyMultiFaced = mysteryCard;
+ *   const mfc: ScryfallCard.AnySplit = mysteryCard;
  * } else {
  *   const sfc: ScryfallCard.AnySingleFaced = mysteryCard;
  * }

--- a/src/objects/Card/Card.ts
+++ b/src/objects/Card/Card.ts
@@ -11,18 +11,20 @@ type Layout<T extends ScryfallLayout> = Pick<ScryfallCardFields.Core.All, "layou
  * A collection of types representing Scryfall cards of each possible layout.
  *
  *
- * An individual type exists for each possible layout: {@link ScryfallCard.Normal}, {@link ScryfallCard.Transform}, etc.
- *
- * Then various groups exist to help describe cards of indeterminate layout:
- * - {@link ScryfallCard.Any} describes any card at all. Think of it as like `any` but for cards.
+ * This collection is focused around four core varieties of cards:
  * - {@link ScryfallCard.AnySingleFaced} describes any card with one face and no `card_faces` property, e.g. {@link ScryfallCard.Normal Normal} or {@link ScryfallCard.Saga Saga}.
  * - {@link ScryfallCard.AnySingleSidedSplit} describes any card with multiple faces where both faces are on the front, e.g. {@link ScryfallCard.Adventure Adventure}, {@link ScryfallCard.Flip Flip}, or {@link ScryfallCard.Split Split}.
  * - {@link ScryfallCard.AnyDoubleSidedSplit} describes any card with multiple faces where the faces are on the front and back of the card, e.g.  {@link ScryfallCard.Transform Transform},  {@link ScryfallCard.ModalDfc ModalDfc}, or  {@link ScryfallCard.ReversibleCard ReversibleCard}.
  * - {@link ScryfallCard.ReversibleCard} describes solely reversible cards.
+ *
+ * It also provides broader groupings:
+ * - {@link ScryfallCard.Any} describes any card at all. Think of it as like `any` but for cards.
  * - {@link ScryfallCard.AnySplit} is an alias for either AnySingleSidedSplit or AnyDoubleSidedSplit.
  * - {@link ScryfallCard.AnyMultiFaced} is an alias for AnySingleSidedSplit, AnyDoubleSidedSplit, or Reversible. This describes all layouts that can have a `card_faces` field.
  *
  * We recommend starting from `ScryfallCard.Any` to describe generic API responses, and you will need to do type narrowing to access more specific fields.
+ *
+ * An individual type additionally exists for each possible layout: {@link ScryfallCard.Normal}, {@link ScryfallCard.Transform}, etc, which is like the variety they belong to but with the `layout` field guaranteed to be a specific value.
  *
  * @example // Type narrowing by layout
  * const mysteryCard: ScryfallCard.Any = getCard();
@@ -56,7 +58,7 @@ export namespace ScryfallCard {
    * Examples: {@link ScryfallLayout.Normal}, {@link ScryfallLayout.Mutate}, {@link ScryfallLayout.Token}.
    */
   export type AnySingleFaced = AbstractCard &
-    Layout<ScryfallLayoutGroup.SingleFaceType> &
+    Layout<ScryfallLayoutGroup.SingleFacedType> &
     ScryfallCardFields.Gameplay.RootProperties &
     ScryfallCardFields.Gameplay.CardSpecific &
     ScryfallCardFields.Gameplay.CardFaceSpecific &

--- a/src/objects/Card/Card.ts
+++ b/src/objects/Card/Card.ts
@@ -22,9 +22,11 @@ type Layout<T extends `${ScryfallLayout}`> = Pick<ScryfallCardFields.Core.All, "
  * - {@link ScryfallCard.AnySplit} is an alias for either AnySingleSidedSplit or AnyDoubleSidedSplit.
  * - {@link ScryfallCard.AnyMultiFaced} is an alias for AnySingleSidedSplit, AnyDoubleSidedSplit, or Reversible. This describes all layouts that can have a `card_faces` field.
  *
+ * There is also an alias for each possible layout: {@link ScryfallCard.Normal}, {@link ScryfallCard.Transform}, etc.
+ *
  * We recommend starting from {@link ScryfallCard.Any} to describe generic API responses, and you will need to do type narrowing to access more specific fields.
  *
- * An individual type additionally exists for each possible layout: {@link ScryfallCard.Normal}, {@link ScryfallCard.Transform}, etc, which is like the variety they belong to but with the `layout` field guaranteed to be a specific value.
+ * 
  *
  * @example // Type narrowing by layout
  * const mysteryCard: ScryfallCard.Any = getCard();

--- a/src/objects/Card/Card.ts
+++ b/src/objects/Card/Card.ts
@@ -74,10 +74,6 @@ export namespace ScryfallCard {
 
   type DoubleSidedSplit = MultiFace<ScryfallCardFace.DoubleSided> & Layout<ScryfallLayoutGroup.DoubleSidedSplitType>;
 
-  type AlwaysOversized = {
-    oversized: true;
-  };
-
   /** A card with the Normal layout. */
   export type Normal = Layout<ScryfallLayout.Normal> & SingleFace;
 
@@ -103,16 +99,13 @@ export namespace ScryfallCard {
   export type Battle = Layout<ScryfallLayout.Battle> & SingleFace;
 
   /** A card with the Planar layout. */
-  export type Planar = Layout<ScryfallLayout.Planar> & SingleFace & AlwaysOversized;
+  export type Planar = Layout<ScryfallLayout.Planar> & SingleFace;
 
   /** A card with the Scheme layout. */
-  export type Scheme = Layout<ScryfallLayout.Scheme> & SingleFace & AlwaysOversized;
+  export type Scheme = Layout<ScryfallLayout.Scheme> & SingleFace;
 
   /** A card with the Vanguard layout. */
-  export type Vanguard = Layout<ScryfallLayout.Vanguard> &
-    SingleFace &
-    ScryfallCardFields.Gameplay.VanguardStats &
-    ScryfallCardFields.Gameplay.NoCombatStats;
+  export type Vanguard = Layout<ScryfallLayout.Vanguard> & SingleFace;
 
   /** A card with the Token layout. */
   export type Token = Layout<ScryfallLayout.Token> & SingleFace;

--- a/src/objects/Card/CardFields.ts
+++ b/src/objects/Card/CardFields.ts
@@ -359,8 +359,10 @@ export namespace ScryfallCardFields.Print {
     artist_ids?: string[];
     /**
      * The lit Unfinity attractions lights on this card, if any.
+     *
+     * This will be an array of numbers ranging from 1 to 6 inclusive.
      */
-    attraction_lights?: (1 | 2 | 3 | 4 | 5 | 6)[];
+    attraction_lights?: number[];
     /**
      * Whether this card is found in boosters.
      */

--- a/src/objects/Card/CardFields.ts
+++ b/src/objects/Card/CardFields.ts
@@ -1,29 +1,26 @@
 import {
-  ScryfallFinishLike,
-  ScryfallBorderColorLike,
+  ScryfallBorderColor,
   ScryfallColors,
-  ScryfallFormat,
-  ScryfallFrameEffectLike,
-  ScryfallFrameLike,
-  ScryfallGameLike,
-  ScryfallImageStatusLike,
+  ScryfallFinish,
+  ScryfallFrame,
+  ScryfallFrameEffect,
+  ScryfallGame,
+  ScryfallImageStatus,
   ScryfallImageUris,
-  ScryfallLanguageCodeLike,
-  ScryfallLayoutLike,
-  ScryfallLegalityLike,
+  ScryfallLanguageCode,
+  ScryfallLayout,
+  ScryfallLegalitiesField,
   ScryfallPrices,
   ScryfallPromoType,
   ScryfallPurchaseUris,
-  ScryfallRarityLike,
+  ScryfallRarity,
   ScryfallRelatedUris,
-  ScryfallSecurityStampLike,
+  ScryfallSecurityStamp,
 } from "./values";
 import { ScryfallCardFace } from "./CardFace";
-import { SetTypeLike } from "../Set/values";
 import { ScryfallRelatedCard } from "./RelatedCard";
 import { ScryfallManaTypes } from "./values/ManaType";
-
-type LegalityRecord = Record<ScryfallFormat, ScryfallLegalityLike>;
+import { SetType } from "../Set/values";
 
 /**
  * A collection of types related to each possible card field.
@@ -49,13 +46,13 @@ export namespace ScryfallCardFields.Core {
     /**
      * A language code for this printing.
      */
-    lang: ScryfallLanguageCodeLike;
+    lang: `${ScryfallLanguageCode}`;
     /**
      * A code for this card’s layout.
      *
      * @see {@link https://scryfall.com/docs/api/layouts}
      */
-    layout: ScryfallLayoutLike;
+    layout: `${ScryfallLayout}`;
     /**
      * A link to where you can begin paginating all re/prints for this card on Scryfall’s API.
      *
@@ -142,7 +139,7 @@ export namespace ScryfallCardFields.Gameplay {
     /**
      * An object describing the legality of this card across play formats. Possible legalities are legal, not_legal, restricted, and banned.
      */
-    legalities: LegalityRecord;
+    legalities: ScryfallLegalitiesField;
   };
 
   /**
@@ -370,7 +367,7 @@ export namespace ScryfallCardFields.Print {
     /**
      * This card’s border color: black, white, borderless, silver, or gold.
      */
-    border_color: ScryfallBorderColorLike;
+    border_color: `${ScryfallBorderColor}`;
     /**
      * This card’s collector number. Note that collector numbers can contain non-numeric characters, such as letters or ★.
      */
@@ -386,15 +383,15 @@ export namespace ScryfallCardFields.Print {
     /**
      * An array of computer-readable flags that indicate if this card can come in foil, nonfoil, or etched finishes.
      */
-    finishes: ScryfallFinishLike[];
+    finishes: `${ScryfallFinish}`[];
     /**
      * This card’s frame effects, if any.
      */
-    frame_effects?: ScryfallFrameEffectLike[];
+    frame_effects?: `${ScryfallFrameEffect}`[];
     /**
      * This card’s frame layout.
      */
-    frame: ScryfallFrameLike;
+    frame: `${ScryfallFrame}`;
     /**
      * True if this card’s artwork is larger than normal.
      */
@@ -402,7 +399,7 @@ export namespace ScryfallCardFields.Print {
     /**
      * A list of games that this card print is available in, paper, arena, and/or mtgo.
      */
-    games: ScryfallGameLike[];
+    games: `${ScryfallGame}`[];
     /**
      * True if this card’s imagery is high resolution.
      */
@@ -416,7 +413,7 @@ export namespace ScryfallCardFields.Print {
     /**
      * A computer-readable indicator for the state of this card’s image, one of missing, placeholder, lowres, or highres_scan.
      */
-    image_status: ScryfallImageStatusLike;
+    image_status: `${ScryfallImageStatus}`;
     /**
      * True if this card is oversized.
      */
@@ -440,7 +437,7 @@ export namespace ScryfallCardFields.Print {
     /**
      * This card’s rarity.
      */
-    rarity: ScryfallRarityLike;
+    rarity: `${ScryfallRarity}`;
     /**
      * An object providing URIs to this card’s listing on other Magic: The Gathering online resources.
      */
@@ -474,7 +471,7 @@ export namespace ScryfallCardFields.Print {
     /**
      * The type of set this printing is in.
      */
-    set_type: SetTypeLike;
+    set_type: `${SetType}`;
     /**
      * A link to this card’s set object on Scryfall’s API.
      *
@@ -502,7 +499,7 @@ export namespace ScryfallCardFields.Print {
     /**
      * The security stamp on this card, if any.
      */
-    security_stamp?: ScryfallSecurityStampLike;
+    security_stamp?: `${ScryfallSecurityStamp}`;
     /**
      * Preview information for this print, if any.
      */

--- a/src/objects/Card/CardFields.ts
+++ b/src/objects/Card/CardFields.ts
@@ -33,11 +33,17 @@ export namespace ScryfallCardFields {}
 
 export namespace ScryfallCardFields.Core {
   export type ScryfallReferences = {
-    /** A unique ID for this card in Scryfall’s database. */
+    /**
+     * A unique ID for this card in Scryfall’s database.
+     */
     id: Uuid;
-    /** A unique ID for this card’s oracle identity. This value is consistent across reprinted card editions, and unique among different cards with the same name (tokens, Unstable variants, etc). Always present except for the reversible_card layout where it will be absent; oracle_id will be found on each face instead. */
+    /**
+     * A unique ID for this card’s oracle identity. This value is consistent across reprinted card editions, and unique among different cards with the same name (tokens, Unstable variants, etc). Always present except for the reversible_card layout where it will be absent; oracle_id will be found on each face instead.
+     */
     oracle_id: Uuid;
-    /** A language code for this printing. */
+    /**
+     * A language code for this printing.
+     */
     lang: ScryfallLanguageCodeLike;
     /**
      * A code for this card’s layout.
@@ -45,30 +51,52 @@ export namespace ScryfallCardFields.Core {
      * @see {@link https://scryfall.com/docs/api/layouts}
      */
     layout: ScryfallLayoutLike;
-    /** A link to where you can begin paginating all re/prints for this card on Scryfall’s API. */
+    /**
+     * A link to where you can begin paginating all re/prints for this card on Scryfall’s API.
+     */
     prints_search_uri: Uri;
-    /** A link to this card’s rulings list on Scryfall’s API. */
+    /**
+     * A link to this card’s rulings list on Scryfall’s API.
+     */
     rulings_uri: Uri;
-    /** A link to this card’s permapage on Scryfall’s website. */
+    /**
+     * A link to this card’s permapage on Scryfall’s website.
+     */
     scryfall_uri: Uri;
-    /** A link to this card object on Scryfall’s API.  */
+    /**
+     * A link to this card object on Scryfall’s API.
+     */
     uri: Uri;
   };
 
   export type VendorReferences = {
-    /** This card’s Arena ID, if any. A large percentage of cards are not available on Arena and do not have this ID. */
+    /**
+     * This card’s Arena ID, if any. A large percentage of cards are not available on Arena and do not have this ID.
+     */
     arena_id?: Integer;
-    /** This card’s Magic Online ID (also known as the Catalog ID), if any. A large percentage of cards are not available on Magic Online and do not have this ID. */
+    /**
+     * This card’s Magic Online ID (also known as the Catalog ID), if any. A large percentage of cards are not available on Magic Online and do not have this ID.
+     */
     mtgo_id?: Integer;
-    /** This card’s foil Magic Online ID (also known as the Catalog ID), if any. A large percentage of cards are not available on Magic Online and do not have this ID. */
+    /**
+     * This card’s foil Magic Online ID (also known as the Catalog ID), if any. A large percentage of cards are not available on Magic Online and do not have this ID.
+     */
     mtgo_foil_id?: Integer;
-    /** This card’s multiverse IDs on Gatherer, if any, as an array of integers. Note that Scryfall includes many promo cards, tokens, and other esoteric objects that do not have these identifiers. */
+    /**
+     * This card’s multiverse IDs on Gatherer, if any, as an array of integers. Note that Scryfall includes many promo cards, tokens, and other esoteric objects that do not have these identifiers.
+     */
     multiverse_ids?: Integer[];
-    /** This card’s ID on TCGplayer’s API, also known as the productId. */
+    /**
+     * This card’s ID on TCGplayer’s API, also known as the productId.
+     */
     tcgplayer_id?: Integer;
-    /** This card’s ID on TCGplayer’s API, for its etched version if that version is a separate product. */
+    /**
+     * This card’s ID on TCGplayer’s API, for its etched version if that version is a separate product.
+     */
     tcgplayer_etched_id?: Integer;
-    /** This card’s ID on Cardmarket’s API, also known as the idProduct. */
+    /**
+     * This card’s ID on Cardmarket’s API, also known as the idProduct.
+     */
     cardmarket_id?: Integer;
   };
 
@@ -80,9 +108,13 @@ export namespace ScryfallCardFields.Gameplay {
    * These fields are always at the root level for every layout.
    */
   export type RootProperties = {
-    /** If this card is closely related to other cards, this property will be an array with Related Card Objects. */
+    /**
+     * If this card is closely related to other cards, this property will be an array with Related Card Objects.
+     */
     all_parts?: ScryfallRelatedCard[];
-    /** An object describing the legality of this card across play formats. Possible legalities are legal, not_legal, restricted, and banned. */
+    /**
+     * An object describing the legality of this card across play formats. Possible legalities are legal, not_legal, restricted, and banned.
+     */
     legalities: LegalityRecord;
   };
 
@@ -90,7 +122,9 @@ export namespace ScryfallCardFields.Gameplay {
    * The card faces field. The faces will be of type T.
    */
   export type CardFaces<T extends ScryfallCardFace.AbstractCardFace> = {
-    /** An array of Card Face objects, if this card is multifaced. */
+    /**
+     * An array of Card Face objects, if this card is multifaced.
+     */
     card_faces: T[];
   };
 
@@ -98,13 +132,19 @@ export namespace ScryfallCardFields.Gameplay {
    * These fields are present only for Vanguards.
    */
   export type VanguardStats = {
-    /** This card’s hand modifier, if it is Vanguard card. This value will contain a delta, such as -1. */
+    /**
+     * This card’s hand modifier, if it is Vanguard card. This value will contain a delta, such as -1.
+     */
     hand_modifier: string;
-    /** This card’s life modifier, if it is Vanguard card. This value will contain a delta, such as +2. */
+    /**
+     * This card’s life modifier, if it is Vanguard card. This value will contain a delta, such as +2.
+     */
     life_modifier: string;
   };
 
-  /** On multi-face cards, these fields are duplicated at the card and print level. */
+  /**
+   * On multi-face cards, these fields are duplicated at the card and print level.
+   */
   type AllFacesAndSides = {
     name: string;
     type_line: string;
@@ -117,17 +157,27 @@ export namespace ScryfallCardFields.Gameplay {
    * These are automatically part of {@link CardFaceSpecific}.
    */
   export type CombatStats = {
-    /** This card's defense, if any. */
+    /**
+     * This card's defense, if any.
+     */
     defense?: string;
-    /** This loyalty if any. Note that some cards have loyalties that are not numeric, such as X. */
+    /**
+     * This loyalty if any. Note that some cards have loyalties that are not numeric, such as X.
+     */
     loyalty?: string;
-    /** This card’s power, if any. Note that some cards have powers that are not numeric, such as `"*"`. */
+    /**
+     * This card’s power, if any. Note that some cards have powers that are not numeric, such as `"*"`.
+     */
     power?: string;
-    /** This card’s toughness, if any. Note that some cards have toughnesses that are not numeric, such as `"*"`. */
+    /**
+     * This card’s toughness, if any. Note that some cards have toughnesses that are not numeric, such as `"*"`.
+     */
     toughness?: string;
   };
 
-  /** A definition implying this object will never, ever have combat stats. */
+  /**
+   * A definition implying this object will never, ever have combat stats.
+   */
   export type NoCombatStats = CombatStats & {
     defense?: undefined;
     loyalty?: undefined;
@@ -142,24 +192,40 @@ export namespace ScryfallCardFields.Gameplay {
    * - Card face level for a multi-face card.
    */
   export type CardFaceSpecific = AllFacesAndSides & {
-    /** The colors in this card’s color indicator, if any. A null value for this field indicates the card does not have one. */
+    /**
+     * The colors in this card’s color indicator, if any. A null value for this field indicates the card does not have one.
+     */
     color_indicator?: ScryfallColors;
-    /** Nullable 	The mana cost for this card. This value will be any empty string "" if the cost is absent. Remember that per the game rules, a missing mana cost and a mana cost of {0} are different  Multi-faced cards will report this value in card faces. */
+    /**
+     * Nullable 	The mana cost for this card. This value will be any empty string "" if the cost is absent. Remember that per the game rules, a missing mana cost and a mana cost of {0} are different  Multi-faced cards will report this value in card faces.
+     */
     mana_cost?: string;
-    /** The name of this card. */
+    /**
+     * The name of this card.
+     */
     name: string;
-    /** The type line of this card. */
+    /**
+     * The type line of this card.
+     */
     type_line: string;
-    /** The Oracle text for this card, if any. */
+    /**
+     * The Oracle text for this card, if any.
+     */
     oracle_text: string;
   } & CombatStats;
 
   export type CardSideSpecific = AllFacesAndSides & {
-    /** The name of this card. */
+    /**
+     * The name of this card.
+     */
     name: string;
-    /** The type line of this card. */
+    /**
+     * The type line of this card.
+     */
     type_line: string;
-    /** This card’s colors, if the overall card has colors defined by the rules. Otherwise the colors will be on the card_faces objects. */
+    /**
+     * This card’s colors, if the overall card has colors defined by the rules. Otherwise the colors will be on the card_faces objects.
+     */
     colors: ScryfallColors;
   };
 
@@ -169,34 +235,58 @@ export namespace ScryfallCardFields.Gameplay {
    * - Card face level for reversible layouts.
    */
   export type CardSpecific = AllFacesAndSides & {
-    /** The card’s mana value. Note that some funny cards have fractional mana costs. */
+    /**
+     * The card’s mana value. Note that some funny cards have fractional mana costs.
+     */
     cmc: Decimal;
-    /** This card’s color identity. */
+    /**
+     * This card’s color identity.
+     */
     color_identity: ScryfallColors;
-    /** This card’s overall rank/popularity on EDHREC. Not all cards are ranked. */
+    /**
+     * This card’s overall rank/popularity on EDHREC. Not all cards are ranked.
+     */
     edhrec_rank?: Integer;
-    /** An array of keywords that this card uses, such as 'Flying' and 'Cumulative upkeep'. */
+    /**
+     * An array of keywords that this card uses, such as 'Flying' and 'Cumulative upkeep'.
+     */
     keywords: string[];
-    /** The name of this card. If this card has multiple faces, this field will contain both names separated by ␣//␣. */
+    /**
+     * The name of this card. If this card has multiple faces, this field will contain both names separated by ␣//␣.
+     */
     name: string;
-    /** This card’s rank/popularity on Penny Dreadful. Not all cards are ranked. */
+    /**
+     * This card’s rank/popularity on Penny Dreadful. Not all cards are ranked.
+     */
     penny_rank?: Integer;
-    /** Colors of mana that this card could produce. */
+    /**
+     * Colors of mana that this card could produce.
+     */
     produced_mana?: ScryfallManaTypes;
-    /** True if this card is on the Reserved List. */
+    /**
+     * True if this card is on the Reserved List.
+     */
     reserved: boolean;
-    /** The type line of this card. */
+    /**
+     * The type line of this card.
+     */
     type_line: string;
   };
 }
 
 export namespace ScryfallCardFields.Print {
   type PreviewInfo = {
-    /** The date this card was previewed. */
+    /**
+     * The date this card was previewed.
+     */
     previewed_at: IsoDate;
-    /** A link to the preview for this card. */
+    /**
+     * A link to the preview for this card.
+     */
     source_uri: Uri;
-    /** The name of the source that previewed this card. */
+    /**
+     * The name of the source that previewed this card.
+     */
     source: string;
   };
 
@@ -220,77 +310,149 @@ export namespace ScryfallCardFields.Print {
    * - Card face level for a reversible card.
    */
   export type CardSpecific = {
-    /** The name of the illustrator of this card. Newly spoiled cards may not have this field yet. */
+    /**
+     * The name of the illustrator of this card. Newly spoiled cards may not have this field yet.
+     */
     artist?: string;
-    /** The IDs of the artists that illustrated this card. Newly spoiled cards may not have this field yet. */
+    /**
+     * The IDs of the artists that illustrated this card. Newly spoiled cards may not have this field yet.
+     */
     artist_ids?: Uuid[];
-    /** The lit Unfinity attractions lights on this card, if any. */
+    /**
+     * The lit Unfinity attractions lights on this card, if any.
+     */
     attraction_lights?: (1 | 2 | 3 | 4 | 5 | 6)[];
-    /** Whether this card is found in boosters. */
+    /**
+     * Whether this card is found in boosters.
+     */
     booster: boolean;
-    /** This card’s border color: black, white, borderless, silver, or gold. */
+    /**
+     * This card’s border color: black, white, borderless, silver, or gold.
+     */
     border_color: ScryfallBorderColorLike;
-    /** This card’s collector number. Note that collector numbers can contain non-numeric characters, such as letters or ★. */
+    /**
+     * This card’s collector number. Note that collector numbers can contain non-numeric characters, such as letters or ★.
+     */
     collector_number: string;
-    /** True if you should consider avoiding use of this print downstream. */
+    /**
+     * True if you should consider avoiding use of this print downstream.
+     */
     content_warning?: boolean;
-    /** True if this card was only released in a video game. */
+    /**
+     * True if this card was only released in a video game.
+     */
     digital: boolean;
-    /** An array of computer-readable flags that indicate if this card can come in foil, nonfoil, or etched finishes. */
+    /**
+     * An array of computer-readable flags that indicate if this card can come in foil, nonfoil, or etched finishes.
+     */
     finishes: ScryfallFinishLike[];
-    /** This card’s frame effects, if any. */
+    /**
+     * This card’s frame effects, if any.
+     */
     frame_effects?: ScryfallFrameEffectLike[];
-    /** This card’s frame layout. */
+    /**
+     * This card’s frame layout.
+     */
     frame: ScryfallFrameLike;
-    /** True if this card’s artwork is larger than normal. */
+    /**
+     * True if this card’s artwork is larger than normal.
+     */
     full_art: boolean;
-    /** A list of games that this card print is available in, paper, arena, and/or mtgo. */
+    /**
+     * A list of games that this card print is available in, paper, arena, and/or mtgo.
+     */
     games: ScryfallGameLike[];
-    /** True if this card’s imagery is high resolution. */
+    /**
+     * True if this card’s imagery is high resolution.
+     */
     highres_image: boolean;
-    /** A unique identifier for the card artwork that remains consistent across reprints. Newly spoiled cards may not have this field yet. */
+    /**
+     * A unique identifier for the card artwork that remains consistent across reprints. Newly spoiled cards may not have this field yet.
+     */
     illustration_id?: Uuid;
-    /** A computer-readable indicator for the state of this card’s image, one of missing, placeholder, lowres, or highres_scan. */
+    /**
+     * A computer-readable indicator for the state of this card’s image, one of missing, placeholder, lowres, or highres_scan.
+     */
     image_status: ScryfallImageStatusLike;
-    /** True if this card is oversized. */
+    /**
+     * True if this card is oversized.
+     */
     oversized: boolean;
-    /** An object containing daily price information for this card, including usd, usd_foil, usd_etched, eur, eur_foil, eur_etched, and tix prices, as strings. */
+    /**
+     * An object containing daily price information for this card, including usd, usd_foil, usd_etched, eur, eur_foil, eur_etched, and tix prices, as strings.
+     */
     prices: ScryfallPrices;
-    /** True if this card is a promotional print. */
+    /**
+     * True if this card is a promotional print.
+     */
     promo: boolean;
-    /** An array of strings describing what categories of promo cards this card falls into. */
+    /**
+     * An array of strings describing what categories of promo cards this card falls into.
+     */
     promo_types?: ScryfallPromoType[];
-    /** An object providing URIs to this card’s listing on major marketplaces. Omitted if the card is unpurchaseable. */
+    /**
+     * An object providing URIs to this card’s listing on major marketplaces. Omitted if the card is unpurchaseable.
+     */
     purchase_uris?: ScryfallPurchaseUris;
-    /** This card’s rarity. */
+    /**
+     * This card’s rarity.
+     */
     rarity: ScryfallRarityLike;
-    /** An object providing URIs to this card’s listing on other Magic: The Gathering online resources. */
+    /**
+     * An object providing URIs to this card’s listing on other Magic: The Gathering online resources.
+     */
     related_uris: ScryfallRelatedUris;
-    /** The date this card was first released. */
+    /**
+     * The date this card was first released.
+     */
     released_at: IsoDate;
-    /** True if this card is a reprint. */
+    /**
+     * True if this card is a reprint.
+     */
     reprint: boolean;
-    /** A link to this card’s set on Scryfall’s website. */
+    /**
+     * A link to this card’s set on Scryfall’s website.
+     */
     scryfall_set_uri: Uri;
-    /** This card’s full set name. */
+    /**
+     * This card’s full set name.
+     */
     set_name: string;
-    /** A link to where you can begin paginating this card’s set on the Scryfall API. */
+    /**
+     * A link to where you can begin paginating this card’s set on the Scryfall API.
+     */
     set_search_uri: Uri;
-    /** The type of set this printing is in. */
+    /**
+     * The type of set this printing is in.
+     */
     set_type: SetTypeLike;
-    /** A link to this card’s set object on Scryfall’s API. */
+    /**
+     * A link to this card’s set object on Scryfall’s API.
+     */
     set_uri: Uri;
-    /** This card’s set code. */
+    /**
+     * This card’s set code.
+     */
     set: string;
-    /** This card’s Set object UUID. */
+    /**
+     * This card’s Set object UUID.
+     */
     set_id: Uuid;
-    /** True if this card is a Story Spotlight. */
+    /**
+     * True if this card is a Story Spotlight.
+     */
     story_spotlight: boolean;
-    /** True if the card is printed without text. */
+    /**
+     * True if the card is printed without text.
+     */
     textless: boolean;
-    /** The security stamp on this card, if any. */
+    /**
+     * The security stamp on this card, if any.
+     */
     security_stamp?: ScryfallSecurityStampLike;
-    /** Preview information for this print, if any. */
+    /**
+     * Preview information for this print, if any.
+     */
     preview?: PreviewInfo;
   } & VariationInfo;
 
@@ -298,7 +460,9 @@ export namespace ScryfallCardFields.Print {
    * These print fields only show up when a card is single-sided.
    */
   export type SingleSideOnly = {
-    /** The Scryfall ID for the card back design present on this card. */
+    /**
+     * The Scryfall ID for the card back design present on this card.
+     */
     card_back_id: Uuid;
   };
 
@@ -309,7 +473,9 @@ export namespace ScryfallCardFields.Print {
    * - Card face level for cards with two sides, e.g. a DFC or a reversible card.
    */
   export type CardSideSpecific = {
-    /** An object listing available imagery for this card. See the Card Imagery article for more information. */
+    /**
+     * An object listing available imagery for this card. See the Card Imagery article for more information.
+     */
     image_uris?: ScryfallImageUris;
   };
 
@@ -320,11 +486,17 @@ export namespace ScryfallCardFields.Print {
    * - Card face level for a multi-faced card.
    */
   export type CardFaceSpecific = {
-    /** The just-for-fun name printed on the card (such as for Godzilla series cards). */
+    /**
+     * The just-for-fun name printed on the card (such as for Godzilla series cards).
+     */
     flavor_name?: string;
-    /** The flavor text, if any. */
+    /**
+     * The flavor text, if any.
+     */
     flavor_text?: string;
-    /** This card’s watermark, if any. */
+    /**
+     * This card’s watermark, if any.
+     */
     watermark?: string;
   } & Localization;
 
@@ -332,11 +504,17 @@ export namespace ScryfallCardFields.Print {
    * These print fields only ever show up on a card face.
    */
   export type CardFaceOnly = {
-    /** The name of the illustrator of this card face. Newly spoiled cards may not have this field yet. */
+    /**
+     * The name of the illustrator of this card face. Newly spoiled cards may not have this field yet.
+     */
     artist?: string;
-    /** The ID of the illustrator of this card face. Newly spoiled cards may not have this field yet. */
+    /**
+     * The ID of the illustrator of this card face. Newly spoiled cards may not have this field yet.
+     */
     artist_id?: Uuid;
-    /** A unique identifier for the card face artwork that remains consistent across reprints. Newly spoiled cards may not have this field yet. */
+    /**
+     * A unique identifier for the card face artwork that remains consistent across reprints. Newly spoiled cards may not have this field yet.
+     */
     illustration_id?: Uuid;
   };
 
@@ -344,11 +522,17 @@ export namespace ScryfallCardFields.Print {
    * Printed data for localized cards.
    */
   export type Localization = {
-    /** The localized name printed on this card, if any. */
+    /**
+     * The localized name printed on this card, if any.
+     */
     printed_name?: string;
-    /** The localized text printed on this card, if any. */
+    /**
+     * The localized text printed on this card, if any.
+     */
     printed_text?: string;
-    /** The localized type line printed on this card, if any. */
+    /**
+     * The localized type line printed on this card, if any.
+     */
     printed_type_line?: string;
   };
 
@@ -362,9 +546,13 @@ export namespace ScryfallCardFields.Print {
   };
 
   type VariationInfo = {
-    /** Whether this card is a variation of another printing. */
+    /**
+     * Whether this card is a variation of another printing.
+     */
     variation: boolean;
-    /** The printing ID of the printing this card is a variation of. */
+    /**
+     * The printing ID of the printing this card is a variation of.
+     */
     variation_of?: Uuid;
   } & (
     | {

--- a/src/objects/Card/CardFields.ts
+++ b/src/objects/Card/CardFields.ts
@@ -159,26 +159,15 @@ export namespace ScryfallCardFields.Gameplay {
     /**
      * This card’s hand modifier, if it is Vanguard card. This value will contain a delta, such as -1.
      */
-    hand_modifier: string;
+    hand_modifier?: string;
     /**
      * This card’s life modifier, if it is Vanguard card. This value will contain a delta, such as +2.
      */
-    life_modifier: string;
-  };
-
-  /**
-   * On multi-face cards, these fields are duplicated at the card and print level.
-   */
-  type AllFacesAndSides = {
-    name: string;
-    type_line: string;
-    mana_cost?: string;
+    life_modifier?: string;
   };
 
   /**
    * Combat stats: power, toughness, loyalty, and defense.
-   *
-   * These are automatically part of {@link CardFaceSpecific}.
    */
   export type CombatStats = {
     /**
@@ -200,13 +189,12 @@ export namespace ScryfallCardFields.Gameplay {
   };
 
   /**
-   * A definition implying this object will never, ever have combat stats.
+   * On multi-face cards, these fields are duplicated at the card and print level.
    */
-  export type NoCombatStats = CombatStats & {
-    defense?: undefined;
-    loyalty?: undefined;
-    power?: undefined;
-    toughness?: undefined;
+  type AllFacesAndSides = {
+    name: string;
+    type_line: string;
+    mana_cost?: string;
   };
 
   /**
@@ -236,7 +224,8 @@ export namespace ScryfallCardFields.Gameplay {
      * The Oracle text for this card, if any.
      */
     oracle_text: string;
-  } & CombatStats;
+  } & CombatStats &
+    VanguardStats;
 
   export type CardSideSpecific = AllFacesAndSides & {
     /**
@@ -590,15 +579,6 @@ export namespace ScryfallCardFields.Print {
      * The localized type line printed on this card, if any.
      */
     printed_type_line?: string;
-  };
-
-  /**
-   * An implication this card will have no localisation data.
-   */
-  export type NotLocalized = {
-    printed_name?: undefined;
-    printed_text?: undefined;
-    printed_type_line?: undefined;
   };
 
   type VariationInfo = {

--- a/src/objects/Card/CardFields.ts
+++ b/src/objects/Card/CardFields.ts
@@ -19,7 +19,6 @@ import {
   ScryfallSecurityStampLike,
 } from "./values";
 import { ScryfallCardFace } from "./CardFace";
-import { Uuid, Uri, Integer, Decimal, IsoDate } from "../../internal";
 import { SetTypeLike } from "../Set/values";
 import { ScryfallRelatedCard } from "./RelatedCard";
 import { ScryfallManaTypes } from "./values/ManaType";
@@ -35,12 +34,18 @@ export namespace ScryfallCardFields.Core {
   export type ScryfallReferences = {
     /**
      * A unique ID for this card in Scryfall’s database.
+     *
+     * @type UUID
      */
-    id: Uuid;
+    id: string;
     /**
-     * A unique ID for this card’s oracle identity. This value is consistent across reprinted card editions, and unique among different cards with the same name (tokens, Unstable variants, etc). Always present except for the reversible_card layout where it will be absent; oracle_id will be found on each face instead.
+     * A unique ID for this card’s oracle identity.
+     * This value is consistent across reprinted card editions, and unique among different cards with the same name (tokens, Unstable variants, etc).
+     * Always present except for the reversible_card layout where it will be absent; oracle_id will be found on each face instead.
+     *
+     * @type UUID
      */
-    oracle_id: Uuid;
+    oracle_id: string;
     /**
      * A language code for this printing.
      */
@@ -53,51 +58,73 @@ export namespace ScryfallCardFields.Core {
     layout: ScryfallLayoutLike;
     /**
      * A link to where you can begin paginating all re/prints for this card on Scryfall’s API.
+     *
+     * @type URI
      */
-    prints_search_uri: Uri;
+    prints_search_uri: string;
     /**
      * A link to this card’s rulings list on Scryfall’s API.
+     *
+     * @type URI
      */
-    rulings_uri: Uri;
+    rulings_uri: string;
     /**
      * A link to this card’s permapage on Scryfall’s website.
+     *
+     * @type URI
      */
-    scryfall_uri: Uri;
+    scryfall_uri: string;
     /**
      * A link to this card object on Scryfall’s API.
+     *
+     * @type URI
      */
-    uri: Uri;
+    uri: string;
   };
 
   export type VendorReferences = {
     /**
      * This card’s Arena ID, if any. A large percentage of cards are not available on Arena and do not have this ID.
+     *
+     * @type Integer
      */
-    arena_id?: Integer;
+    arena_id?: number;
     /**
      * This card’s Magic Online ID (also known as the Catalog ID), if any. A large percentage of cards are not available on Magic Online and do not have this ID.
+     *
+     * @type Integer
      */
-    mtgo_id?: Integer;
+    mtgo_id?: number;
     /**
      * This card’s foil Magic Online ID (also known as the Catalog ID), if any. A large percentage of cards are not available on Magic Online and do not have this ID.
+     *
+     * @type Integer
      */
-    mtgo_foil_id?: Integer;
+    mtgo_foil_id?: number;
     /**
      * This card’s multiverse IDs on Gatherer, if any, as an array of integers. Note that Scryfall includes many promo cards, tokens, and other esoteric objects that do not have these identifiers.
+     *
+     * @type Integer
      */
-    multiverse_ids?: Integer[];
+    multiverse_ids?: number[];
     /**
      * This card’s ID on TCGplayer’s API, also known as the productId.
+     *
+     * @type Integer
      */
-    tcgplayer_id?: Integer;
+    tcgplayer_id?: number;
     /**
      * This card’s ID on TCGplayer’s API, for its etched version if that version is a separate product.
+     *
+     * @type Integer
      */
-    tcgplayer_etched_id?: Integer;
+    tcgplayer_etched_id?: number;
     /**
      * This card’s ID on Cardmarket’s API, also known as the idProduct.
+     *
+     * @type Integer
      */
-    cardmarket_id?: Integer;
+    cardmarket_id?: number;
   };
 
   export type All = ScryfallReferences & VendorReferences;
@@ -237,16 +264,20 @@ export namespace ScryfallCardFields.Gameplay {
   export type CardSpecific = AllFacesAndSides & {
     /**
      * The card’s mana value. Note that some funny cards have fractional mana costs.
+     *
+     * @type Decimal
      */
-    cmc: Decimal;
+    cmc: number;
     /**
      * This card’s color identity.
      */
     color_identity: ScryfallColors;
     /**
      * This card’s overall rank/popularity on EDHREC. Not all cards are ranked.
+     *
+     * @type Integer
      */
-    edhrec_rank?: Integer;
+    edhrec_rank?: number;
     /**
      * An array of keywords that this card uses, such as 'Flying' and 'Cumulative upkeep'.
      */
@@ -257,8 +288,10 @@ export namespace ScryfallCardFields.Gameplay {
     name: string;
     /**
      * This card’s rank/popularity on Penny Dreadful. Not all cards are ranked.
+     *
+     * @type Integer
      */
-    penny_rank?: Integer;
+    penny_rank?: number;
     /**
      * Colors of mana that this card could produce.
      */
@@ -278,12 +311,16 @@ export namespace ScryfallCardFields.Print {
   type PreviewInfo = {
     /**
      * The date this card was previewed.
+     *
+     * @type IsoDate
      */
-    previewed_at: IsoDate;
+    previewed_at: string;
     /**
      * A link to the preview for this card.
+     *
+     * @type URI
      */
-    source_uri: Uri;
+    source_uri: string;
     /**
      * The name of the source that previewed this card.
      */
@@ -316,8 +353,10 @@ export namespace ScryfallCardFields.Print {
     artist?: string;
     /**
      * The IDs of the artists that illustrated this card. Newly spoiled cards may not have this field yet.
+     *
+     * @type UUID
      */
-    artist_ids?: Uuid[];
+    artist_ids?: string[];
     /**
      * The lit Unfinity attractions lights on this card, if any.
      */
@@ -368,8 +407,10 @@ export namespace ScryfallCardFields.Print {
     highres_image: boolean;
     /**
      * A unique identifier for the card artwork that remains consistent across reprints. Newly spoiled cards may not have this field yet.
+     *
+     * @type UUID
      */
-    illustration_id?: Uuid;
+    illustration_id?: string;
     /**
      * A computer-readable indicator for the state of this card’s image, one of missing, placeholder, lowres, or highres_scan.
      */
@@ -404,40 +445,50 @@ export namespace ScryfallCardFields.Print {
     related_uris: ScryfallRelatedUris;
     /**
      * The date this card was first released.
+     *
+     * @type IsoDate
      */
-    released_at: IsoDate;
+    released_at: string;
     /**
      * True if this card is a reprint.
      */
     reprint: boolean;
     /**
      * A link to this card’s set on Scryfall’s website.
+     *
+     * @type URI
      */
-    scryfall_set_uri: Uri;
+    scryfall_set_uri: string;
     /**
      * This card’s full set name.
      */
     set_name: string;
     /**
      * A link to where you can begin paginating this card’s set on the Scryfall API.
+     *
+     * @type URI
      */
-    set_search_uri: Uri;
+    set_search_uri: string;
     /**
      * The type of set this printing is in.
      */
     set_type: SetTypeLike;
     /**
      * A link to this card’s set object on Scryfall’s API.
+     *
+     * @type URI
      */
-    set_uri: Uri;
+    set_uri: string;
     /**
      * This card’s set code.
      */
     set: string;
     /**
      * This card’s Set object UUID.
+     *
+     * @type UUID
      */
-    set_id: Uuid;
+    set_id: string;
     /**
      * True if this card is a Story Spotlight.
      */
@@ -462,8 +513,10 @@ export namespace ScryfallCardFields.Print {
   export type SingleSideOnly = {
     /**
      * The Scryfall ID for the card back design present on this card.
+     *
+     * @type UUID
      */
-    card_back_id: Uuid;
+    card_back_id: string;
   };
 
   /**
@@ -510,12 +563,16 @@ export namespace ScryfallCardFields.Print {
     artist?: string;
     /**
      * The ID of the illustrator of this card face. Newly spoiled cards may not have this field yet.
+     *
+     * @type UUID
      */
-    artist_id?: Uuid;
+    artist_id?: string;
     /**
      * A unique identifier for the card face artwork that remains consistent across reprints. Newly spoiled cards may not have this field yet.
+     *
+     * @type UUID
      */
-    illustration_id?: Uuid;
+    illustration_id?: string;
   };
 
   /**
@@ -552,16 +609,11 @@ export namespace ScryfallCardFields.Print {
     variation: boolean;
     /**
      * The printing ID of the printing this card is a variation of.
+     *
+     * This will only exist if the `variation` field is true.
+     *
+     * @type UUID
      */
-    variation_of?: Uuid;
-  } & (
-    | {
-        variation: true;
-        variation_of: Uuid;
-      }
-    | {
-        variation: false;
-        variation_of?: undefined;
-      }
-  );
+    variation_of?: string;
+  };
 }

--- a/src/objects/Card/RelatedCard.ts
+++ b/src/objects/Card/RelatedCard.ts
@@ -1,5 +1,4 @@
 import { ScryfallObject } from "../Object";
-import { Uri, Uuid } from "../../internal";
 
 /**
  * A related card entry.
@@ -7,8 +6,10 @@ import { Uri, Uuid } from "../../internal";
 export type ScryfallRelatedCard = ScryfallObject.Object<ScryfallObject.ObjectType.RelatedCard> & {
   /**
    * An unique ID for this card in Scryfall’s database.
+   *
+   * @type UUID
    */
-  id: Uuid;
+  id: string;
   /**
    * A field explaining what role this card plays in this relationship.
    */
@@ -23,6 +24,8 @@ export type ScryfallRelatedCard = ScryfallObject.Object<ScryfallObject.ObjectTyp
   type_line: string;
   /**
    * A URI where you can retrieve a full object describing this card on Scryfall’s API.
+   *
+   * @type URI
    */
-  uri: Uri;
+  uri: string;
 };

--- a/src/objects/Card/values/BorderColor.ts
+++ b/src/objects/Card/values/BorderColor.ts
@@ -10,5 +10,3 @@ export enum ScryfallBorderColor {
   Silver = "silver",
   Gold = "gold",
 }
-
-export type ScryfallBorderColorLike = ScryfallBorderColor | `${ScryfallBorderColor}`;

--- a/src/objects/Card/values/Color.ts
+++ b/src/objects/Card/values/Color.ts
@@ -8,6 +8,4 @@ export enum ScryfallColor {
   Colorless = "C",
 }
 
-export type ScryfallColorLike = ScryfallColor | `${ScryfallColor}`;
-
-export type ScryfallColors = ScryfallColorLike[];
+export type ScryfallColors = `${ScryfallColor}`[];

--- a/src/objects/Card/values/Finish.ts
+++ b/src/objects/Card/values/Finish.ts
@@ -3,5 +3,3 @@ export enum ScryfallFinish {
   Foil = "foil",
   Etched = "etched",
 }
-
-export type ScryfallFinishLike = ScryfallFinish | `${ScryfallFinish}`;

--- a/src/objects/Card/values/FrameEffect.ts
+++ b/src/objects/Card/values/FrameEffect.ts
@@ -46,5 +46,3 @@ export enum ScryfallFrameEffect {
   /** The cards have the Upside Down transforming marks */
   UpsidedownDfc = "upsidedowndfc",
 }
-
-export type ScryfallFrameEffectLike = ScryfallFrameEffect | `${ScryfallFrameEffect}`;

--- a/src/objects/Card/values/Game.ts
+++ b/src/objects/Card/values/Game.ts
@@ -27,5 +27,3 @@ export enum ScryfallGame {
    */
   Sega = "sega",
 }
-
-export type ScryfallGameLike = ScryfallGame | `${ScryfallGame}`;

--- a/src/objects/Card/values/ImageSize.ts
+++ b/src/objects/Card/values/ImageSize.ts
@@ -55,5 +55,3 @@ export enum ScryfallImageSize {
    */
   BorderCrop = "border_crop",
 }
-
-export type ScryfallImageSizeLike = ScryfallImageSize | `${ScryfallImageSize}`;

--- a/src/objects/Card/values/ImageStatus.ts
+++ b/src/objects/Card/values/ImageStatus.ts
@@ -20,5 +20,3 @@ export enum ScryfallImageStatus {
    */
   HighResScan = "highres_scan",
 }
-
-export type ScryfallImageStatusLike = ScryfallImageStatus | `${ScryfallImageStatus}`;

--- a/src/objects/Card/values/ImageUris.ts
+++ b/src/objects/Card/values/ImageUris.ts
@@ -1,8 +1,6 @@
-import { Uri } from "../../../internal";
-
 import { ScryfallImageSize } from "./ImageSize";
 
 /**
  * URIs for various image sizes of this card.
  */
-export type ScryfallImageUris = Record<ScryfallImageSize, Uri>;
+export type ScryfallImageUris = Record<ScryfallImageSize, string>;

--- a/src/objects/Card/values/LanguageCode.ts
+++ b/src/objects/Card/values/LanguageCode.ts
@@ -39,5 +39,3 @@ export enum ScryfallLanguageCode {
   /** Phyrexian */
   Phyrexian = "ph",
 }
-
-export type ScryfallLanguageCodeLike = ScryfallLanguageCode | `${ScryfallLanguageCode}`;

--- a/src/objects/Card/values/Layout.ts
+++ b/src/objects/Card/values/Layout.ts
@@ -52,8 +52,6 @@ export enum ScryfallLayout {
   Case = "case",
 }
 
-export type ScryfallLayoutLike = ScryfallLayout | `${ScryfallLayout}`;
-
 /**
  * Groupings of layouts.
  */

--- a/src/objects/Card/values/Layout.ts
+++ b/src/objects/Card/values/Layout.ts
@@ -57,36 +57,53 @@ export enum ScryfallLayout {
  */
 export namespace ScryfallLayoutGroup {
   /**
-   * A type describing all layouts that represent a single-faced card, i.e. one with no card_faces property.
+   * All layouts that represent a single-faced card, i.e. one with no card_faces property.
    */
-  export type SingleFaceType =
-    | ScryfallLayout.Normal
-    | ScryfallLayout.Meld
-    | ScryfallLayout.Leveler
-    | ScryfallLayout.Class
-    | ScryfallLayout.Saga
-    | ScryfallLayout.Mutate
-    | ScryfallLayout.Prototype
-    | ScryfallLayout.Battle
-    | ScryfallLayout.Planar
-    | ScryfallLayout.Scheme
-    | ScryfallLayout.Vanguard
-    | ScryfallLayout.Token
-    | ScryfallLayout.Emblem
-    | ScryfallLayout.Augment
-    | ScryfallLayout.Host;
+  export const SingleFaced = [
+    ScryfallLayout.Normal,
+    ScryfallLayout.Meld,
+    ScryfallLayout.Leveler,
+    ScryfallLayout.Class,
+    ScryfallLayout.Saga,
+    ScryfallLayout.Mutate,
+    ScryfallLayout.Prototype,
+    ScryfallLayout.Battle,
+    ScryfallLayout.Planar,
+    ScryfallLayout.Scheme,
+    ScryfallLayout.Vanguard,
+    ScryfallLayout.Token,
+    ScryfallLayout.Emblem,
+    ScryfallLayout.Augment,
+    ScryfallLayout.Host,
+  ] as const;
 
   /**
-   * A card describing all layouts that represent a multi-faced card where both faces are on the front.
+   * A type describing {@link SingleFaced}.
    */
-  export type SingleSidedSplitType = ScryfallLayout.Split | ScryfallLayout.Flip | ScryfallLayout.Adventure;
+  export type SingleFacedType = (typeof SingleFaced)[number];
 
   /**
-   * A card describing all layouts that represent a multi-faced card where the faces are on the front and back of the card.
+   * All layouts that represent a multi-faced card where both faces are on the front.
    */
-  export type DoubleSidedSplitType =
-    | ScryfallLayout.Transform
-    | ScryfallLayout.ModalDfc
-    | ScryfallLayout.DoubleFacedToken
-    | ScryfallLayout.ArtSeries;
+  export const SingleSidedSplit = [ScryfallLayout.Split, ScryfallLayout.Flip, ScryfallLayout.Adventure] as const;
+
+  /**
+   * A type describing {@link SingleSidedSplit}.
+   */
+  export type SingleSidedSplitType = (typeof SingleSidedSplit)[number];
+
+  /**
+   * All layouts that represent a multi-faced card where the faces are on the front and back of the card.
+   */
+  export const DoubleSidedSplit = [
+    ScryfallLayout.Transform,
+    ScryfallLayout.ModalDfc,
+    ScryfallLayout.DoubleFacedToken,
+    ScryfallLayout.ArtSeries,
+  ] as const;
+
+  /**
+   * A type describing {@link DoubleSidedSplit}.
+   */
+  export type DoubleSidedSplitType = (typeof DoubleSidedSplit)[number];
 }

--- a/src/objects/Card/values/Layout.ts
+++ b/src/objects/Card/values/Layout.ts
@@ -77,19 +77,6 @@ export namespace ScryfallLayoutGroup {
     | ScryfallLayout.Host;
 
   /**
-   * A type describing all layouts that represent a multi-faced card, i.e. one with a card_faces property.
-   */
-  export type MultiFaceType =
-    | ScryfallLayout.Split
-    | ScryfallLayout.Flip
-    | ScryfallLayout.Adventure
-    | ScryfallLayout.Transform
-    | ScryfallLayout.ModalDfc
-    | ScryfallLayout.DoubleFacedToken
-    | ScryfallLayout.ArtSeries
-    | ScryfallLayout.ReversibleCard;
-
-  /**
    * A card describing all layouts that represent a multi-faced card where both faces are on the front.
    */
   export type SingleSidedSplitType = ScryfallLayout.Split | ScryfallLayout.Flip | ScryfallLayout.Adventure;
@@ -101,6 +88,5 @@ export namespace ScryfallLayoutGroup {
     | ScryfallLayout.Transform
     | ScryfallLayout.ModalDfc
     | ScryfallLayout.DoubleFacedToken
-    | ScryfallLayout.ArtSeries
-    | ScryfallLayout.ReversibleCard;
+    | ScryfallLayout.ArtSeries;
 }

--- a/src/objects/Card/values/Layout.ts
+++ b/src/objects/Card/values/Layout.ts
@@ -58,6 +58,8 @@ export enum ScryfallLayout {
 export namespace ScryfallLayoutGroup {
   /**
    * All layouts that represent a single-faced card, i.e. one with no card_faces property.
+   *
+   * @see {@link SingleFacedType} for the type of this group.
    */
   export const SingleFaced = [
     `${ScryfallLayout.Normal}`,
@@ -78,12 +80,16 @@ export namespace ScryfallLayoutGroup {
   ] as const;
 
   /**
-   * A type describing {@link SingleFaced}.
+   * A type for all layouts that represent a single-faced card, i.e. one with no card_faces property.
+   *
+   * @see {@link SingleFaced} for an array version.
    */
   export type SingleFacedType = (typeof SingleFaced)[number];
 
   /**
    * All layouts that represent a multi-faced card where both faces are on the front.
+   *
+   * @see {@link SingleSidedSplitType} for the type of this group.
    */
   export const SingleSidedSplit = [
     `${ScryfallLayout.Split}`,
@@ -92,12 +98,17 @@ export namespace ScryfallLayoutGroup {
   ] as const;
 
   /**
-   * A type describing {@link SingleSidedSplit}.
+   * A type for all layouts that represent a multi-faced card where both faces are on the front.
+   *
+   * @see {@link SingleSidedSplit} for an array version.
+   *
    */
   export type SingleSidedSplitType = (typeof SingleSidedSplit)[number];
 
   /**
    * All layouts that represent a multi-faced card where the faces are on the front and back of the card.
+   *
+   * @see {@link DoubleSidedSplitType} for the type of this group.
    */
   export const DoubleSidedSplit = [
     `${ScryfallLayout.Transform}`,
@@ -107,7 +118,10 @@ export namespace ScryfallLayoutGroup {
   ] as const;
 
   /**
-   * A type describing {@link DoubleSidedSplit}.
+   * A type for all layouts that represent a multi-faced card where the faces are on the front and back of the card.
+   *
+   * @see {@link DoubleSidedSplit} for an array version.
+   *
    */
   export type DoubleSidedSplitType = (typeof DoubleSidedSplit)[number];
 }

--- a/src/objects/Card/values/Layout.ts
+++ b/src/objects/Card/values/Layout.ts
@@ -60,21 +60,21 @@ export namespace ScryfallLayoutGroup {
    * All layouts that represent a single-faced card, i.e. one with no card_faces property.
    */
   export const SingleFaced = [
-    ScryfallLayout.Normal,
-    ScryfallLayout.Meld,
-    ScryfallLayout.Leveler,
-    ScryfallLayout.Class,
-    ScryfallLayout.Saga,
-    ScryfallLayout.Mutate,
-    ScryfallLayout.Prototype,
-    ScryfallLayout.Battle,
-    ScryfallLayout.Planar,
-    ScryfallLayout.Scheme,
-    ScryfallLayout.Vanguard,
-    ScryfallLayout.Token,
-    ScryfallLayout.Emblem,
-    ScryfallLayout.Augment,
-    ScryfallLayout.Host,
+    `${ScryfallLayout.Normal}`,
+    `${ScryfallLayout.Meld}`,
+    `${ScryfallLayout.Leveler}`,
+    `${ScryfallLayout.Class}`,
+    `${ScryfallLayout.Saga}`,
+    `${ScryfallLayout.Mutate}`,
+    `${ScryfallLayout.Prototype}`,
+    `${ScryfallLayout.Battle}`,
+    `${ScryfallLayout.Planar}`,
+    `${ScryfallLayout.Scheme}`,
+    `${ScryfallLayout.Vanguard}`,
+    `${ScryfallLayout.Token}`,
+    `${ScryfallLayout.Emblem}`,
+    `${ScryfallLayout.Augment}`,
+    `${ScryfallLayout.Host}`,
   ] as const;
 
   /**
@@ -85,7 +85,11 @@ export namespace ScryfallLayoutGroup {
   /**
    * All layouts that represent a multi-faced card where both faces are on the front.
    */
-  export const SingleSidedSplit = [ScryfallLayout.Split, ScryfallLayout.Flip, ScryfallLayout.Adventure] as const;
+  export const SingleSidedSplit = [
+    `${ScryfallLayout.Split}`,
+    `${ScryfallLayout.Flip}`,
+    `${ScryfallLayout.Adventure}`,
+  ] as const;
 
   /**
    * A type describing {@link SingleSidedSplit}.
@@ -96,10 +100,10 @@ export namespace ScryfallLayoutGroup {
    * All layouts that represent a multi-faced card where the faces are on the front and back of the card.
    */
   export const DoubleSidedSplit = [
-    ScryfallLayout.Transform,
-    ScryfallLayout.ModalDfc,
-    ScryfallLayout.DoubleFacedToken,
-    ScryfallLayout.ArtSeries,
+    `${ScryfallLayout.Transform}`,
+    `${ScryfallLayout.ModalDfc}`,
+    `${ScryfallLayout.DoubleFacedToken}`,
+    `${ScryfallLayout.ArtSeries}`,
   ] as const;
 
   /**

--- a/src/objects/Card/values/LegalitiesField.ts
+++ b/src/objects/Card/values/LegalitiesField.ts
@@ -1,0 +1,4 @@
+import { ScryfallFormat } from "./Format";
+import { ScryfallLegality } from "./Legality";
+
+export type ScryfallLegalitiesField = Record<ScryfallFormat, ScryfallLegality>;

--- a/src/objects/Card/values/LegalitiesField.ts
+++ b/src/objects/Card/values/LegalitiesField.ts
@@ -1,4 +1,4 @@
 import { ScryfallFormat } from "./Format";
 import { ScryfallLegality } from "./Legality";
 
-export type ScryfallLegalitiesField = Record<ScryfallFormat, ScryfallLegality>;
+export type ScryfallLegalitiesField = Record<`${ScryfallFormat}`, `${ScryfallLegality}`>;

--- a/src/objects/Card/values/Legality.ts
+++ b/src/objects/Card/values/Legality.ts
@@ -4,5 +4,3 @@ export enum ScryfallLegality {
   Restricted = "restricted",
   Banned = "banned",
 }
-
-export type ScryfallLegalityLike = ScryfallLegality | `${ScryfallLegality}`;

--- a/src/objects/Card/values/ManaType.ts
+++ b/src/objects/Card/values/ManaType.ts
@@ -7,6 +7,4 @@ enum ScryfallManaType {
   Colorless = "C",
 }
 
-export type ScryfallManaTypeLike = ScryfallManaType | `${ScryfallManaType}`;
-
-export type ScryfallManaTypes = ScryfallManaTypeLike[];
+export type ScryfallManaTypes = `${ScryfallManaType}`[];

--- a/src/objects/Card/values/PurchaseUris.ts
+++ b/src/objects/Card/values/PurchaseUris.ts
@@ -1,14 +1,23 @@
-import { Uri } from "../../../internal";
-
-
 /**
  * Possible purchase URIs for a card.
  */
 export type ScryfallPurchaseUris = {
-  /** This card's purchase page on TCGPlayer. */
-  tcgplayer: Uri;
-  /** This card's purchase page on Cardmarket. Often inexact due to how Cardmarket links work. */
-  cardmarket: Uri;
-  /** This card's purchase page on Cardhoarder. */
-  cardhoarder: Uri;
+  /**
+   * This card's purchase page on TCGPlayer.
+   *
+   * @type URI
+   */
+  tcgplayer: string;
+  /**
+   * This card's purchase page on Cardmarket. Often inexact due to how Cardmarket links work.
+   *
+   * @type URI
+   */
+  cardmarket: string;
+  /**
+   * This card's purchase page on Cardhoarder.
+   *
+   * @type URI
+   */
+  cardhoarder: string;
 };

--- a/src/objects/Card/values/Rarity.ts
+++ b/src/objects/Card/values/Rarity.ts
@@ -6,5 +6,3 @@ export enum ScryfallRarity {
   Mythic = "mythic",
   Bonus = "bonus",
 }
-
-export type ScryfallRarityLike = ScryfallRarity | `${ScryfallRarity}`;

--- a/src/objects/Card/values/RelatedUris.ts
+++ b/src/objects/Card/values/RelatedUris.ts
@@ -1,16 +1,29 @@
-import { Uri } from "../../../internal";
-
-
 /**
  * Related URIs for a card.
  */
 export type ScryfallRelatedUris = {
-  /** This card's Gatherer page. */
-  gatherer?: Uri;
-  /** TCGPlayer Infinite articles related to this card. */
-  tcgplayer_infinite_articles?: Uri;
-  /** TCGPlayer Infinite decks with this card. */
-  tcgplayer_infinite_decks?: Uri;
-  /** EDHREC's page for this card. */
-  edhrec?: Uri;
+  /**
+   * This card's Gatherer page.
+   *
+   * @type URI
+   */
+  gatherer?: string;
+  /**
+   * TCGPlayer Infinite articles related to this card.
+   *
+   * @type URI
+   */
+  tcgplayer_infinite_articles?: string;
+  /**
+   * TCGPlayer Infinite decks with this card.
+   *
+   * @type URI
+   */
+  tcgplayer_infinite_decks?: string;
+  /**
+   * EDHREC's page for this card.
+   *
+   * @type URI
+   */
+  edhrec?: string;
 };

--- a/src/objects/Card/values/SecurityStamp.ts
+++ b/src/objects/Card/values/SecurityStamp.ts
@@ -6,5 +6,3 @@ export enum ScryfallSecurityStamp {
   Arena = "arena",
   Heart = "heart",
 }
-
-export type ScryfallSecurityStampLike = ScryfallSecurityStamp | `${ScryfallSecurityStamp}`;

--- a/src/objects/Card/values/index.ts
+++ b/src/objects/Card/values/index.ts
@@ -8,6 +8,7 @@ export * from "./Game";
 export * from "./ImageSize";
 export * from "./ImageStatus";
 export * from "./ImageUris";
+export * from "./LegalitiesField";
 export * from "./LanguageCode";
 export * from "./Layout";
 export * from "./Legality";

--- a/src/objects/Catalog/Catalog.ts
+++ b/src/objects/Catalog/Catalog.ts
@@ -7,10 +7,16 @@ import { Uri, Integer } from "../../internal";
  * @see {@link https://scryfall.com/docs/api/catalogs}
  */
 export type ScryfallCatalog = ScryfallObject.Object<ScryfallObject.ObjectType.Catalog> & {
-  /** A link to the current catalog on Scryfall’s API */
+  /**
+   * A link to the current catalog on Scryfall’s API
+   */
   uri: Uri;
-  /** The number of items in the `data` array */
+  /**
+   * The number of items in the `data` array
+   */
   total_values: Integer;
-  /** An array of datapoints, as strings */
+  /**
+   * An array of datapoints, as strings
+   */
   data: string[];
 };

--- a/src/objects/Catalog/Catalog.ts
+++ b/src/objects/Catalog/Catalog.ts
@@ -1,5 +1,4 @@
 import { ScryfallObject } from "../Object";
-import { Uri, Integer } from "../../internal";
 
 /**
  * A catalog of values.
@@ -9,12 +8,16 @@ import { Uri, Integer } from "../../internal";
 export type ScryfallCatalog = ScryfallObject.Object<ScryfallObject.ObjectType.Catalog> & {
   /**
    * A link to the current catalog on Scryfall’s API
+   *
+   * @type URI
    */
-  uri: Uri;
+  uri: string;
   /**
    * The number of items in the `data` array
+   *
+   * @type Integer
    */
-  total_values: Integer;
+  total_values: number;
   /**
    * An array of datapoints, as strings
    */

--- a/src/objects/Error/Error.ts
+++ b/src/objects/Error/Error.ts
@@ -1,5 +1,4 @@
 import { ScryfallObject } from "../Object";
-import { Integer } from "../../internal";
 
 /**
  * An error response from the Scryfall API.
@@ -11,8 +10,10 @@ import { Integer } from "../../internal";
 export type ScryfallError = ScryfallObject.Object<ScryfallObject.ObjectType.Error> & {
   /**
    * An integer HTTP status code for this error.
+   *
+   * @type Integer
    */
-  status: Integer;
+  status: number;
   /**
    * A computer-friendly string representing the appropriate HTTP status code.
    */

--- a/src/objects/List/List.ts
+++ b/src/objects/List/List.ts
@@ -1,5 +1,4 @@
 import { ScryfallObject } from "../Object";
-import { Integer, Uri } from "../../internal";
 import { ScryfallCard } from "../Card";
 import { ScryfallMigration } from "../Migration";
 import { ScryfallRuling } from "../Ruling";
@@ -28,12 +27,19 @@ export namespace ScryfallList {
     has_more: boolean;
     /**
      * If there is a page beyond the current page, this field will contain a full API URI to that page. You may submit a HTTP GET request to that URI to continue paginating forward on this List.
+     *
+     * This is only defined when `has_more` is true.
+     *
+     * @type URI
      */
-    next_page?: Uri;
+    next_page?: string;
     /**
      * If this is a list of Card objects, this field will contain the total number of cards found across all pages.
+     * Otherwise this field will be undefined.
+     *
+     * @type Integer
      */
-    total_cards?: Integer;
+    total_cards?: number;
     /**
      * An array of human-readable warnings issued when generating this list, as strings.
      *
@@ -42,23 +48,7 @@ export namespace ScryfallList {
      * You should fix the warnings and re-submit your request.
      */
     warnings?: string[];
-  } & (
-      | {
-          has_more: true;
-          next_page: Uri;
-        }
-      | {
-          has_more: false;
-          next_page?: undefined;
-        }
-    ) &
-    (T extends ScryfallCard.AbstractCard
-      ? {
-          total_cards: Integer;
-        }
-      : {
-          total_cards?: undefined;
-        });
+  };
 
   /**
    * A list of cards.

--- a/src/objects/Migration/Migration.ts
+++ b/src/objects/Migration/Migration.ts
@@ -14,21 +14,37 @@ export type ScryfallMigrationStrategyLike = ScryfallMigrationStrategy | `${Scryf
  * @see {@link https://scryfall.com/docs/api/migrations}
  */
 export type ScryfallMigration = ScryfallObject.Object<ScryfallObject.ObjectType.Migration> & {
-  /** A link to the current object on Scryfall's API */
+  /**
+   * A link to the current object on Scryfall's API
+   */
   uri: Uri;
-  /** This migration's unique UUID */
+  /**
+   * This migration's unique UUID
+   */
   id: Uuid;
-  /** The date this migration was performed */
+  /**
+   * The date this migration was performed
+   */
   performed_at: IsoDate;
-  /** A computer-readable indicator of the migration strategy. */
+  /**
+   * A computer-readable indicator of the migration strategy.
+   */
   migration_strategy: ScryfallMigrationStrategyLike;
-  /** The `id` of the affected API Card object */
+  /**
+   * The `id` of the affected API Card object
+   */
   old_scryfall_id: Uuid;
-  /** The replacement `id` of the API Card object if this is a `merge` */
+  /**
+   * The replacement `id` of the API Card object if this is a `merge`
+   */
   new_scryfall_id?: Uuid;
-  /** A note left by the Scryfall team about this migration */
+  /**
+   * A note left by the Scryfall team about this migration
+   */
   note?: string;
-  /** Additional context Scryfall has provided for this migration, designed to be human-read only */
+  /**
+   * Additional context Scryfall has provided for this migration, designed to be human-read only
+   */
   metadata?: object;
 } & (
     | {

--- a/src/objects/Migration/Migration.ts
+++ b/src/objects/Migration/Migration.ts
@@ -5,8 +5,6 @@ export enum ScryfallMigrationStrategy {
   Delete = "delete",
 }
 
-export type ScryfallMigrationStrategyLike = ScryfallMigrationStrategy | `${ScryfallMigrationStrategy}`;
-
 /**
  * A data migration.
  *
@@ -34,7 +32,7 @@ export type ScryfallMigration = ScryfallObject.Object<ScryfallObject.ObjectType.
   /**
    * A computer-readable indicator of the migration strategy.
    */
-  migration_strategy: ScryfallMigrationStrategyLike;
+  migration_strategy: `${ScryfallMigrationStrategy}`;
   /**
    * The `id` of the affected API Card object
    *

--- a/src/objects/Migration/Migration.ts
+++ b/src/objects/Migration/Migration.ts
@@ -1,5 +1,4 @@
 import { ScryfallObject } from "../Object";
-import { Uri, Uuid, IsoDate } from "../../internal";
 
 export enum ScryfallMigrationStrategy {
   Merge = "merge",
@@ -16,28 +15,38 @@ export type ScryfallMigrationStrategyLike = ScryfallMigrationStrategy | `${Scryf
 export type ScryfallMigration = ScryfallObject.Object<ScryfallObject.ObjectType.Migration> & {
   /**
    * A link to the current object on Scryfall's API
+   *
+   * @type URI
    */
-  uri: Uri;
+  uri: string;
   /**
    * This migration's unique UUID
+   *
+   * @type UUID
    */
-  id: Uuid;
+  id: string;
   /**
    * The date this migration was performed
+   *
+   * @type IsoDate
    */
-  performed_at: IsoDate;
+  performed_at: string;
   /**
    * A computer-readable indicator of the migration strategy.
    */
   migration_strategy: ScryfallMigrationStrategyLike;
   /**
    * The `id` of the affected API Card object
+   *
+   * @type UUID
    */
-  old_scryfall_id: Uuid;
+  old_scryfall_id: string;
   /**
    * The replacement `id` of the API Card object if this is a `merge`
+   *
+   * @type UUID
    */
-  new_scryfall_id?: Uuid;
+  new_scryfall_id?: string;
   /**
    * A note left by the Scryfall team about this migration
    */
@@ -46,13 +55,4 @@ export type ScryfallMigration = ScryfallObject.Object<ScryfallObject.ObjectType.
    * Additional context Scryfall has provided for this migration, designed to be human-read only
    */
   metadata?: object;
-} & (
-    | {
-        migration_strategy: ScryfallMigrationStrategy.Merge | `${ScryfallMigrationStrategy.Merge}`;
-        new_scryfall_id: Uuid;
-      }
-    | {
-        migration_strategy: ScryfallMigrationStrategy.Delete | `${ScryfallMigrationStrategy.Delete}`;
-        new_scryfall_id?: undefined;
-      }
-  );
+};

--- a/src/objects/Object/Object.ts
+++ b/src/objects/Object/Object.ts
@@ -52,8 +52,6 @@ export namespace ScryfallObject {
     Set = "set",
   }
 
-  export type ObjectTypeLike = ObjectType | `${ObjectType}`;
-
   /**
    * The abstract base type of Scryfall objects.
    */

--- a/src/objects/Object/Object.ts
+++ b/src/objects/Object/Object.ts
@@ -58,7 +58,9 @@ export namespace ScryfallObject {
    * The abstract base type of Scryfall objects.
    */
   export type Object<T extends ObjectType> = {
-    /** A content type for this object. */
+    /**
+     * A content type for this object.
+     */
     object: T | `${T}`;
   };
 }

--- a/src/objects/Ruling/Ruling.ts
+++ b/src/objects/Ruling/Ruling.ts
@@ -1,5 +1,4 @@
 import { ScryfallObject } from "../Object";
-import { IsoDate, Uuid } from "../../internal";
 
 /**
  * Rulings made on a card by the rules manager.
@@ -9,16 +8,20 @@ import { IsoDate, Uuid } from "../../internal";
 export type ScryfallRuling = ScryfallObject.Object<ScryfallObject.ObjectType.Ruling> & {
   /**
    * The Oracle ID of the card this ruling is associated with.
+   *
+   * @type UUID
    */
-  oracle_id: Uuid;
+  oracle_id: string;
   /**
    * A computer-readable string indicating which company produced this ruling, either `wotc` or `scryfall`
    */
   source: "wotc" | "scryfall";
   /**
    * The date when the ruling or note was published
+   *
+   * @type IsoDate
    */
-  published_at: IsoDate;
+  published_at: string;
   /**
    * The text of the ruling
    */

--- a/src/objects/Set/Set.ts
+++ b/src/objects/Set/Set.ts
@@ -1,5 +1,5 @@
 import { ScryfallObject } from "../Object";
-import { SetTypeLike } from "./values";
+import { SetType } from "./values";
 
 /**
  * Description of a Magic card set.
@@ -38,7 +38,7 @@ export type ScryfallSet = ScryfallObject.Object<ScryfallObject.ObjectType.Set> &
   /**
    * A computer-readable classification for this set. See below.
    */
-  set_type: SetTypeLike;
+  set_type: `${SetType}`;
   /**
    * The date the set was released or the first card was printed in the set (in GMT-8 Pacific time).
    *

--- a/src/objects/Set/Set.ts
+++ b/src/objects/Set/Set.ts
@@ -1,5 +1,4 @@
 import { ScryfallObject } from "../Object";
-import { Uuid, Integer, Uri, IsoDate } from "../../internal";
 import { SetTypeLike } from "./values";
 
 /**
@@ -10,8 +9,10 @@ import { SetTypeLike } from "./values";
 export type ScryfallSet = ScryfallObject.Object<ScryfallObject.ObjectType.Set> & {
   /**
    * A unique ID for this set on Scryfall that will not change.
+   *
+   * @type UUID
    */
-  id: Uuid;
+  id: string;
   /**
    * The unique three to five-letter code for this set.
    */
@@ -26,8 +27,10 @@ export type ScryfallSet = ScryfallObject.Object<ScryfallObject.ObjectType.Set> &
   arena_code?: string;
   /**
    * This set’s ID on TCGplayer’s API, also known as the groupId.
+   *
+   * @type Integer
    */
-  tcgplayer_id?: Integer;
+  tcgplayer_id?: number;
   /**
    * The English name of the set.
    */
@@ -38,8 +41,10 @@ export type ScryfallSet = ScryfallObject.Object<ScryfallObject.ObjectType.Set> &
   set_type: SetTypeLike;
   /**
    * The date the set was released or the first card was printed in the set (in GMT-8 Pacific time).
+   *
+   * @type IsoDate
    */
-  released_at?: IsoDate;
+  released_at?: string;
   /**
    * The block code for this set, if any.
    */
@@ -54,12 +59,16 @@ export type ScryfallSet = ScryfallObject.Object<ScryfallObject.ObjectType.Set> &
   parent_set_code?: string;
   /**
    * The number of cards in this set.
+   *
+   * @type Integer
    */
-  card_count: Integer;
+  card_count: number;
   /**
    * The denominator for the set’s printed collector numbers.
+   *
+   * @type Integer
    */
-  printed_size?: Integer;
+  printed_size?: number;
   /**
    * True if this set was only released in a video game.
    */
@@ -74,18 +83,26 @@ export type ScryfallSet = ScryfallObject.Object<ScryfallObject.ObjectType.Set> &
   nonfoil_only: boolean;
   /**
    * A link to this set’s permapage on Scryfall’s website.
+   *
+   * @type URI
    */
-  scryfall_uri: Uri;
+  scryfall_uri: string;
   /**
    * A link to this set object on Scryfall’s API.
+   *
+   * @type URI
    */
-  uri: Uri;
+  uri: string;
   /**
    * A URI to an SVG file for this set’s icon on Scryfall’s CDN. Hotlinking this image isn’t recommended, because it may change slightly over time. You should download it and use it locally for your particular user interface needs.
+   *
+   * @type URI
    */
-  icon_svg_uri: Uri;
+  icon_svg_uri: string;
   /**
    * A Scryfall API URI that you can request to begin paginating over the cards in this set.
+   *
+   * @type URI
    */
-  search_uri: Uri;
+  search_uri: string;
 };

--- a/src/objects/Set/values/SetType.ts
+++ b/src/objects/Set/values/SetType.ts
@@ -68,5 +68,3 @@ export enum SetType {
   /** A set that contains minigame card inserts from booster packs */
   Minigame = "minigame",
 }
-
-export type SetTypeLike = SetType | `${SetType}`;

--- a/src/objects/Symbology/CardSymbol.ts
+++ b/src/objects/Symbology/CardSymbol.ts
@@ -1,5 +1,4 @@
 import { ScryfallObject } from "../Object";
-import { Decimal, Uri } from "../../internal";
 import { ScryfallColors } from "../Card/values";
 
 /**
@@ -30,12 +29,16 @@ export type ScryfallCardSymbol = ScryfallObject.Object<ScryfallObject.ObjectType
   represents_mana: boolean;
   /**
    * A decimal number representing this symbol’s mana value (also knowns as the converted mana cost). Note that mana symbols from funny sets can have fractional mana values.
+   *
+   * @type Decimal
    */
-  mana_value?: Decimal | null;
+  mana_value?: number | null;
   /**
    * @deprecated Use {@link ScryfallCardSymbol.mana_value} instead.
+   *
+   * @type Decimal
    */
-  cmc?: Decimal | null;
+  cmc?: number | null;
   /**
    * True if this symbol appears in a mana cost on any Magic card. For example {20} has this field set to false because {20} only appears in Oracle text, not mana costs.
    */
@@ -62,6 +65,8 @@ export type ScryfallCardSymbol = ScryfallObject.Object<ScryfallObject.ObjectType
   gatherer_alternates?: string[] | null;
   /**
    * A URI to an SVG image of this symbol on Scryfall’s CDNs.
+   *
+   * @type URI
    */
-  svg_uri?: Uri;
+  svg_uri?: string;
 };

--- a/src/objects/Symbology/ManaCost.ts
+++ b/src/objects/Symbology/ManaCost.ts
@@ -1,5 +1,4 @@
 import { ScryfallObject } from "../Object";
-import { Decimal } from "../../internal";
 import { ScryfallColors } from "../Card/values";
 
 /**
@@ -14,8 +13,10 @@ export type ScryfallManaCost = ScryfallObject.Object<ScryfallObject.ObjectType.M
   cost: string;
   /**
    * The mana value. If you submit Un-set mana symbols, this decimal could include fractional parts
+   *
+   * @type Decimal
    */
-  cmc: Decimal;
+  cmc: number;
   /**
    * The colors of the given cost
    */


### PR DESCRIPTION
This PR introduces a much simpler card model.

- Resolves #20
- Also incorporates (hopefully sensibly) some valid critique raised by @thesilican in a comment on that issue: https://github.com/scryfall/api-types/issues/20#issuecomment-1982421266

# Card model: now broad to specific

Previously, the card model flowed like this, piling on more and more complexity at each step:

1. I defined each very specific layout: Normal, Split, Transform, etc. Each layout might contain very fine-grained details applied to that layout only.
1. I defined `Any` as a collection of all the specific layouts. This meant loading `Any` required the type parser to do a join on all possible layout objects. This was _enormous_ for it to process and involved thousands of possibilities.
1. I defined groupings as an extension of `Any`: `AnySingleFaced` was defined as Any & a narrowing group. This meant groupings came with all the complexity of Any _plus more complexity._

Now we go more of a broad to specific direction.

The _actual_ card units are now the following: `AnySingleFaced`, `AnySingleSidedSplit`, `AnyDoubleSidedSplit`, and the perpetual black sheep `ReversibleCard`. All single faced cards, all single sided split cards, and all double sided split cards share an identical layout. This means for example we don't include `CombatStats` _only_ for adventure and flip cards, but also for regular split cards too, even when it'll never be applicable for those, because it eases consumption.

Specific layouts like `ScryfallCard.Normal` or `ScryfallCard.Transform` are just an alias for the relevant group plus an assertion the `layout` field is set to a specific value.

`ScryfallCard.Any` is now either `AnySingleFaced`, `AnySingleSidedSplit`, `AnyDoubleSidedSplit`, or `ReversibleCard`, so now instead of a range of fifty-ish possible objects, it's a range of four.

# Enum value revisions

Enum values were previously defined like this:

```ts
rarity: ScryfallRarity | `${ScryfallRarity}`
```

The purpose of this was to let you compare or set this field using either the enum (e.g. `ScryfallRarity.Rare`) or a plain string (e.g. `"rare"`.

That definition was a little over-engineered. All of those fields are now defined like this instead:

```ts
rarity: `${ScryfallRarity}`
```

This is sufficient to let you compare or set using the corresponding enum or a plain string. It's also more accurate: these fields were _never_ going to be set to an actual enum member; they would _always_ be a plain string.

# Other changes

- Removed the Primitive type aliases: `Decimal`, `Integer`, `Uuid`, `Uri`, and `IsoDate`. These are now just `string` or `integer`. The primitive type is mentioned still in a `@type` jsdoc field for the reader's benefit; hopefully that won't break anyhting.
- Dropped conditional inclusion of fields (e.g. only making the VanguardStats properties available in one layout) and conditional hard setting of fields (e.g. AlwaysOversized, NoCombatStats). Also dropped conditional guarantees that fields might be exactly `true`, `false`, or `undefined`.
- Revised `ScryfallLayoutGroups` to actually now export arrays of enum values to assist with layout handling, although I can't find a way to make it useful for type narrowing yet.